### PR TITLE
feat: canonical Item CRUD example + Conventions doc

### DIFF
--- a/app/Enums/ItemStatus.php
+++ b/app/Enums/ItemStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ItemStatus: string
+{
+    case Draft    = 'draft';
+    case Active   = 'active';
+    case Archived = 'archived';
+
+    /** Convenience for v-select :items binding. */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $case) => ['title' => $case->label(), 'value' => $case->value],
+            self::cases(),
+        );
+    }
+
+    /** Human label, e.g. for select dropdowns. */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft    => 'Draft',
+            self::Active   => 'Active',
+            self::Archived => 'Archived',
+        };
+    }
+}

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -15,13 +15,26 @@ use Illuminate\Http\Request;
  * Canonical thin controller — delegates validation to FormRequests, response
  * shape to ItemResource, and query filtering to the model's scopeFilter().
  * Every new resource on this stack should look like this.
+ *
+ * Per-record authorization is delegated to App\Policies\ItemPolicy via
+ * `authorizeResource()`, which inserts the matching policy check
+ * (viewAny/view/create/update/delete) before each action runs.
  */
 class ItemController extends Controller
 {
+    public function __construct()
+    {
+        $this->authorizeResource(Item::class, 'item');
+    }
+
     public function index(Request $request): JsonResponse
     {
+        // Explicit whitelist — never forward `$request->all()` into scopeFilter
+        // since other query params (`page`, `sortBy`, etc.) share that namespace.
+        // Eager-load owner so the list view's owner column doesn't N+1.
         $items = Item::query()
-            ->filter($request->all())
+            ->with('owner')
+            ->filter($request->only(['status', 'owner_id', 'search']))
             ->latest('id')
             ->vuetifyPaginate();
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreItemRequest;
+use App\Http\Requests\UpdateItemRequest;
+use App\Http\Resources\ItemResource;
+use App\Models\Item;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Canonical thin controller — delegates validation to FormRequests, response
+ * shape to ItemResource, and query filtering to the model's scopeFilter().
+ * Every new resource on this stack should look like this.
+ */
+class ItemController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $items = Item::query()
+            ->filter($request->all())
+            ->latest('id')
+            ->vuetifyPaginate();
+
+        // ->additional() preserves the vuetifyPaginate envelope while wrapping
+        // each row in ItemResource — frontend keeps its pagination contract.
+        $items->setCollection(
+            $items->getCollection()->map(fn (Item $item) => new ItemResource($item))->collect()
+        );
+
+        return response()->json($items);
+    }
+
+    public function show(Item $item): ItemResource
+    {
+        $item->load('owner');
+
+        return new ItemResource($item);
+    }
+
+    public function store(StoreItemRequest $request): ItemResource
+    {
+        $item = Item::create($request->validated());
+        $item->load('owner');
+
+        return new ItemResource($item);
+    }
+
+    public function update(UpdateItemRequest $request, Item $item): ItemResource
+    {
+        $item->update($request->validated());
+        $item->load('owner');
+
+        return new ItemResource($item);
+    }
+
+    public function destroy(Item $item): JsonResponse
+    {
+        $item->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Requests/StoreItemRequest.php
+++ b/app/Http/Requests/StoreItemRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\ItemStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+class StoreItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // Route is auth:sanctum-gated; per-record permission can layer on top later.
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'        => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'status'      => ['required', new Enum(ItemStatus::class)],
+            'priority'    => ['required', 'integer', 'between:1,5'],
+            'due_date'    => ['nullable', 'date'],
+            'owner_id'    => ['nullable', 'integer', Rule::exists('users', 'id')],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateItemRequest.php
+++ b/app/Http/Requests/UpdateItemRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\ItemStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        // 'sometimes' lets PATCH/PUT clients send partial bodies. The shape mirrors
+        // StoreItemRequest so frontends can reuse the same validation contract.
+        return [
+            'name'        => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:5000'],
+            'status'      => ['sometimes', 'required', new Enum(ItemStatus::class)],
+            'priority'    => ['sometimes', 'required', 'integer', 'between:1,5'],
+            'due_date'    => ['sometimes', 'nullable', 'date'],
+            'owner_id'    => ['sometimes', 'nullable', 'integer', Rule::exists('users', 'id')],
+        ];
+    }
+}

--- a/app/Http/Resources/ItemResource.php
+++ b/app/Http/Resources/ItemResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Item;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Item */
+class ItemResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'          => $this->id,
+            'name'        => $this->name,
+            'description' => $this->description,
+            'status'      => $this->status?->value,
+            'priority'    => $this->priority,
+            'due_date'    => $this->due_date?->toIso8601String(),
+
+            // whenLoaded() lets index lists skip the join cost while detail
+            // views (which eager-load) still include the owner.
+            'owner_id' => $this->owner_id,
+            'owner'    => new AuthUserResource($this->whenLoaded('owner')),
+
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ItemStatus;
+use App\Traits\WhoDidIt;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Item extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+    use WhoDidIt;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'status',
+        'priority',
+        'due_date',
+        'owner_id',
+    ];
+
+    protected $casts = [
+        'status'   => ItemStatus::class,
+        'priority' => 'integer',
+        'due_date' => 'date',
+    ];
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    /**
+     * Apply UI-side filters to the query.
+     *
+     * Accepted keys: status (string), owner_id (int), search (string).
+     * Unknown keys are ignored — controllers can pass `request()->all()` safely.
+     */
+    public function scopeFilter(Builder $query, array $filters): Builder
+    {
+        return $query
+            ->when($filters['status'] ?? null, fn ($q, $status) => $q->where('status', $status))
+            ->when($filters['owner_id'] ?? null, fn ($q, $ownerId) => $q->where('owner_id', (int) $ownerId))
+            ->when($filters['search'] ?? null, function ($q, $search) {
+                $q->where(function (Builder $sub) use ($search) {
+                    $sub->where('name', 'like', "%{$search}%")
+                        ->orWhere('description', 'like', "%{$search}%");
+                });
+            });
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -50,9 +50,12 @@ class Item extends Model
             ->when($filters['status'] ?? null, fn ($q, $status) => $q->where('status', $status))
             ->when($filters['owner_id'] ?? null, fn ($q, $ownerId) => $q->where('owner_id', (int) $ownerId))
             ->when($filters['search'] ?? null, function ($q, $search) {
-                $q->where(function (Builder $sub) use ($search) {
-                    $sub->where('name', 'like', "%{$search}%")
-                        ->orWhere('description', 'like', "%{$search}%");
+                // Escape LIKE wildcards in user input so a search for "100%"
+                // doesn't degenerate into a "contains 100" match.
+                $escaped = addcslashes((string) $search, '%_\\');
+                $q->where(function (Builder $sub) use ($escaped) {
+                    $sub->where('name', 'like', "%{$escaped}%")
+                        ->orWhere('description', 'like', "%{$escaped}%");
                 });
             });
     }

--- a/app/Policies/ItemPolicy.php
+++ b/app/Policies/ItemPolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Item;
+use App\Models\User;
+
+/**
+ * Canonical per-record authorization for the Item resource.
+ *
+ * Resolved automatically by Laravel via the App\Policies\<Model>Policy
+ * naming convention (Gate::policy() is implicit). Wired into the controller
+ * with `$this->authorizeResource(Item::class, 'item')` so every action
+ * checks the matching policy method before running.
+ *
+ * Baseline: any authenticated user can list, view, and create items; only
+ * the owner can update or delete. Adjust per-resource for your real
+ * authorization model (teams, roles, sharing, etc.).
+ */
+class ItemPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Item $item): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Item $item): bool
+    {
+        return $item->owner_id === $user->id;
+    }
+
+    public function delete(User $user, Item $item): bool
+    {
+        return $item->owner_id === $user->id;
+    }
+}

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\ItemStatus;
+use App\Models\Item;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Item>
+ */
+class ItemFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name'        => fake()->sentence(3),
+            'description' => fake()->paragraph(),
+            'status'      => fake()->randomElement(ItemStatus::cases()),
+            'priority'    => fake()->numberBetween(1, 5),
+            'due_date'    => fake()->optional(0.6)->dateTimeBetween('now', '+30 days'),
+            // owner_id is left null by default; tests/seeders pass a User explicitly.
+        ];
+    }
+
+    public function active(): static
+    {
+        return $this->state(fn () => ['status' => ItemStatus::Active]);
+    }
+
+    public function archived(): static
+    {
+        return $this->state(fn () => ['status' => ItemStatus::Archived]);
+    }
+
+    public function ownedBy(int $userId): static
+    {
+        return $this->state(fn () => ['owner_id' => $userId]);
+    }
+}

--- a/database/migrations/2026_05_14_120000_create_items_table.php
+++ b/database/migrations/2026_05_14_120000_create_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('status', 32)->default('active')->index();
+            $table->unsignedTinyInteger('priority')->default(3);
+            $table->date('due_date')->nullable();
+            $table->foreignIdFor(User::class, 'owner_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->whoDidIt();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/docs/Conventions.md
+++ b/docs/Conventions.md
@@ -4,7 +4,7 @@ This document extracts the patterns demonstrated by the `Item` resource into a c
 
 > **AI agents:** treat this as the source-of-truth pattern. When implementing a new feature that adds a resource, mirror these files step for step. The patterns are deliberate; deviating without a reason is the most common source of bugs that QA catches.
 
-## The 11-layer flow
+## The 12-layer flow
 
 Every new resource follows this sequence:
 
@@ -14,13 +14,14 @@ Every new resource follows this sequence:
 | 2 | **Model** | `app/Models/Item.php` | Eloquent model. Always: `HasFactory`, `SoftDeletes`, `WhoDidIt` traits. Define `$fillable`, `$casts`, relations, and a `scopeFilter(array)` that inverts query-string filters. |
 | 3 | **Enum** (if applicable) | `app/Enums/ItemStatus.php` | String-backed enum with `label()` and `options()` static for v-select consumption. Cast on the model. |
 | 4 | **Factory** | `database/factories/ItemFactory.php` | Fake data + named-state helpers (`active()`, `ownedBy($id)`). Tests read more cleanly than inline `->state([…])` calls. |
-| 5 | **FormRequests** | `app/Http/Requests/StoreItemRequest.php` + `UpdateItemRequest.php` | One per verb. Update uses `sometimes` for partial bodies. `authorize()` returns `true` — Sanctum middleware already gates the route; per-record policy layers later. |
-| 6 | **Resource** | `app/Http/Resources/ItemResource.php` | API envelope. ISO 8601 dates. `whenLoaded()` for relations. |
-| 7 | **Controller** | `app/Http/Controllers/ItemController.php` | Thin: model query + FormRequest + Resource. `vuetifyPaginate()` mixin (from `VuetifyPaginateMixin` in AppServiceProvider) emits the pagination shape the frontend `AppPaginationTable` expects. |
-| 8 | **Route** | `routes/api.php` | One line: `Route::apiResource('items', ItemController::class)` inside the `auth:sanctum` group. |
-| 9 | **TS types** (generated) | `resources/ts/types/laravel/` | Run `composer typescript` after backend changes — Wayfinder regenerates these from your routes + FormRequests. |
-| 10 | **Vue list page** | `resources/ts/pages/items/ItemListPage.vue` | Options API. `AppPaginationTable` bound to `endpoint="items"` with a reactive `filters` prop. Slot overrides for non-string columns (chips, dates, related-record names, action buttons). |
-| 11 | **Vue form page** | `resources/ts/pages/items/ItemFormPage.vue` | Options API. ONE component handles create + edit — branch on `$route.params.id`. `AppServerValidationForm` slot props (`submit`, `loading`, `getErrors`) plumb directly to Vuetify field `:loading` / `:error-messages`. |
+| 5 | **FormRequests** | `app/Http/Requests/StoreItemRequest.php` + `UpdateItemRequest.php` | One per verb. Update uses `sometimes` for partial bodies. `authorize()` returns `true` — per-record auth lives in the Policy layer below, FormRequest is just for shape validation. |
+| 6 | **Policy** | `app/Policies/ItemPolicy.php` | Per-record authorization. Laravel auto-resolves `App\Policies\<Model>Policy`. Baseline: any authenticated user can list/view/create; only the owner can update/delete. Adjust per real auth model (teams, roles, sharing). |
+| 7 | **Resource** | `app/Http/Resources/ItemResource.php` | API envelope. ISO 8601 dates. `whenLoaded()` for relations. |
+| 8 | **Controller** | `app/Http/Controllers/ItemController.php` | Thin: model query + FormRequest + Resource. Call `$this->authorizeResource(<Model>::class, '<param>')` in the constructor so the policy fires before every action. `vuetifyPaginate()` mixin (from `VuetifyPaginateMixin` in AppServiceProvider) emits the pagination shape the frontend `AppPaginationTable` expects. |
+| 9 | **Route** | `routes/api.php` | One line: `Route::apiResource('items', ItemController::class)` inside the `auth:sanctum` group. |
+| 10 | **TS types** (generated) | `resources/ts/types/laravel/` | Run `composer typescript` after backend changes — Wayfinder regenerates these from your routes + FormRequests. |
+| 11 | **Vue list page** | `resources/ts/pages/items/ItemListPage.vue` | Options API. `AppPaginationTable` bound to `endpoint="items"` with a reactive `filters` prop. Slot overrides for non-string columns (chips, dates, related-record names, action buttons). |
+| 12 | **Vue form page** | `resources/ts/pages/items/ItemFormPage.vue` | Options API. ONE component handles create + edit — branch on `$route.params.id`. `AppServerValidationForm` slot props (`submit`, `loading`, `getErrors`) plumb directly to Vuetify field `:loading` / `:error-messages`. |
 
 ## Tests (mandatory, not optional)
 
@@ -47,13 +48,14 @@ The two `ItemControllerTest*.php` files are the canonical pattern. Run with `com
 2. `php artisan make:model Thing -f` — add traits + `scopeFilter`.
 3. Maybe an enum in `app/Enums/`.
 4. `php artisan make:request StoreThingRequest UpdateThingRequest` — copy from `StoreItemRequest`/`UpdateItemRequest`.
-5. `php artisan make:resource ThingResource` — copy from `ItemResource`.
-6. `php artisan make:controller ThingController --api --requests` — but discard the boilerplate and copy from `ItemController`.
-7. One line in `routes/api.php`.
-8. `composer typescript` to regen frontend types.
-9. Two Vue files in `resources/ts/pages/things/` — `ThingListPage.vue` and `ThingFormPage.vue`, copied from the Item versions.
-10. Three lines in `router/paths.ts` (ROUTES + the three RouteDesigner.route calls).
-11. Two Feature test files in `tests/Feature/`.
+5. `php artisan make:policy ThingPolicy --model=Thing` — copy from `ItemPolicy`, adjust ownership/visibility rules to match the real auth model. Laravel auto-resolves by name; no provider registration needed.
+6. `php artisan make:resource ThingResource` — copy from `ItemResource`.
+7. `php artisan make:controller ThingController --api --requests` — but discard the boilerplate and copy from `ItemController`, including the `authorizeResource()` call in the constructor.
+8. One line in `routes/api.php`.
+9. `composer typescript` to regen frontend types.
+10. Two Vue files in `resources/ts/pages/things/` — `ThingListPage.vue` and `ThingFormPage.vue`, copied from the Item versions.
+11. Three lines in `router/paths.ts` (ROUTES + the three RouteDesigner.route calls).
+12. Two Feature test files in `tests/Feature/` — including non-owner 403 specs to prove the Policy is wired up.
 
 If a step in this list is genuinely not applicable (e.g. the entity has no enum), skip it. Don't skip a step because it feels like overhead — every step exists because something broke without it in a previous project.
 

--- a/docs/Conventions.md
+++ b/docs/Conventions.md
@@ -1,0 +1,64 @@
+# Canonical Resource Conventions
+
+This document extracts the patterns demonstrated by the `Item` resource into a checklist for building any new resource on this stack. The actual files referenced here are the canonical implementations — copy them as starting points and adapt.
+
+> **AI agents:** treat this as the source-of-truth pattern. When implementing a new feature that adds a resource, mirror these files step for step. The patterns are deliberate; deviating without a reason is the most common source of bugs that QA catches.
+
+## The 11-layer flow
+
+Every new resource follows this sequence:
+
+| # | Layer | Reference file | Purpose |
+|---|---|---|---|
+| 1 | **Migration** | `database/migrations/*_create_items_table.php` | Schema. Always use `$table->whoDidIt()` + `$table->softDeletes()` for any user-editable entity. Index FKs and filter columns. |
+| 2 | **Model** | `app/Models/Item.php` | Eloquent model. Always: `HasFactory`, `SoftDeletes`, `WhoDidIt` traits. Define `$fillable`, `$casts`, relations, and a `scopeFilter(array)` that inverts query-string filters. |
+| 3 | **Enum** (if applicable) | `app/Enums/ItemStatus.php` | String-backed enum with `label()` and `options()` static for v-select consumption. Cast on the model. |
+| 4 | **Factory** | `database/factories/ItemFactory.php` | Fake data + named-state helpers (`active()`, `ownedBy($id)`). Tests read more cleanly than inline `->state([…])` calls. |
+| 5 | **FormRequests** | `app/Http/Requests/StoreItemRequest.php` + `UpdateItemRequest.php` | One per verb. Update uses `sometimes` for partial bodies. `authorize()` returns `true` — Sanctum middleware already gates the route; per-record policy layers later. |
+| 6 | **Resource** | `app/Http/Resources/ItemResource.php` | API envelope. ISO 8601 dates. `whenLoaded()` for relations. |
+| 7 | **Controller** | `app/Http/Controllers/ItemController.php` | Thin: model query + FormRequest + Resource. `vuetifyPaginate()` mixin (from `VuetifyPaginateMixin` in AppServiceProvider) emits the pagination shape the frontend `AppPaginationTable` expects. |
+| 8 | **Route** | `routes/api.php` | One line: `Route::apiResource('items', ItemController::class)` inside the `auth:sanctum` group. |
+| 9 | **TS types** (generated) | `resources/ts/types/laravel/` | Run `composer typescript` after backend changes — Wayfinder regenerates these from your routes + FormRequests. |
+| 10 | **Vue list page** | `resources/ts/pages/items/ItemListPage.vue` | Options API. `AppPaginationTable` bound to `endpoint="items"` with a reactive `filters` prop. Slot overrides for non-string columns (chips, dates, related-record names, action buttons). |
+| 11 | **Vue form page** | `resources/ts/pages/items/ItemFormPage.vue` | Options API. ONE component handles create + edit — branch on `$route.params.id`. `AppServerValidationForm` slot props (`submit`, `loading`, `getErrors`) plumb directly to Vuetify field `:loading` / `:error-messages`. |
+
+## Tests (mandatory, not optional)
+
+Every controller gets two Feature test files:
+
+- `tests/Feature/<Resource>ControllerTest.php` — index + show paths (auth required, pagination shape, filters, eager-loaded relations, 404).
+- `tests/Feature/<Resource>ControllerStoreUpdateDestroyTest.php` — mutations (validation rules, partial-update happy path, WhoDidIt-trait audit columns set correctly, soft-delete behavior).
+
+The two `ItemControllerTest*.php` files are the canonical pattern. Run with `composer ci` (pint --test + pest --parallel) or `./vendor/bin/pest --filter Item`.
+
+## The rules
+
+- **Never put validation in a controller.** FormRequest or nothing.
+- **Never return raw model arrays.** Resource or nothing. The envelope shape is a contract.
+- **Never do query filtering inline in the controller action.** Add a `scopeFilter` on the model.
+- **Always eager-load relations needed by the response.** Don't rely on `automaticallyEagerLoadRelationships()` masking N+1s in production — the warning is dev-only.
+- **Always run `composer typescript` after changing a route, FormRequest, or controller signature.** Otherwise the frontend types lie.
+- **Always wrap forms in `AppServerValidationForm`.** Manual `$http.post` + manual error display = inconsistent UX and missed 422 cases.
+- **Always use the field-component family (`AppDateInput`, `AppAutoComplete`, `AppMaskField`, etc.) over raw Vuetify components** when one fits. They standardize date formats, async loading, masks — saves you from re-deriving each per project.
+
+## Copying for a new resource
+
+1. `php artisan make:migration create_things_table` — fill in fields, add `$table->whoDidIt(); $table->softDeletes();`.
+2. `php artisan make:model Thing -f` — add traits + `scopeFilter`.
+3. Maybe an enum in `app/Enums/`.
+4. `php artisan make:request StoreThingRequest UpdateThingRequest` — copy from `StoreItemRequest`/`UpdateItemRequest`.
+5. `php artisan make:resource ThingResource` — copy from `ItemResource`.
+6. `php artisan make:controller ThingController --api --requests` — but discard the boilerplate and copy from `ItemController`.
+7. One line in `routes/api.php`.
+8. `composer typescript` to regen frontend types.
+9. Two Vue files in `resources/ts/pages/things/` — `ThingListPage.vue` and `ThingFormPage.vue`, copied from the Item versions.
+10. Three lines in `router/paths.ts` (ROUTES + the three RouteDesigner.route calls).
+11. Two Feature test files in `tests/Feature/`.
+
+If a step in this list is genuinely not applicable (e.g. the entity has no enum), skip it. Don't skip a step because it feels like overhead — every step exists because something broke without it in a previous project.
+
+## See also
+
+- `docs/Capacitor.md` — mobile-target opt-in (when applicable).
+- `tests/Feature/ItemControllerTest.php` — Pest 4 test patterns with Sanctum auth + factories.
+- `app/CLAUDE.md`, `resources/ts/CLAUDE.md`, `database/CLAUDE.md` — area-specific conventions (after the P0 cleanup PR merges).

--- a/resources/ts/pages/DashboardPage.vue
+++ b/resources/ts/pages/DashboardPage.vue
@@ -16,6 +16,14 @@
         </div>
       </v-card-text>
       <v-card-actions>
+        <v-btn
+          color="primary"
+          variant="tonal"
+          prepend-icon="list"
+          @click="goItems"
+        >
+          Items
+        </v-btn>
         <v-spacer />
         <v-btn
           color="primary"
@@ -44,6 +52,9 @@ export default defineComponent({
     async logout() {
       await this.$auth.logout()
       await this.$router.push(this.$routeTo(this.ROUTES.LOGIN))
+    },
+    goItems() {
+      this.$router.push(this.$routeTo(this.ROUTES.ITEMS_LIST))
     }
   }
 })

--- a/resources/ts/pages/items/ItemFormPage.vue
+++ b/resources/ts/pages/items/ItemFormPage.vue
@@ -1,0 +1,205 @@
+<template>
+  <v-container fluid>
+    <div class="d-flex align-center mb-4">
+      <v-btn
+        icon="arrow_back"
+        variant="text"
+        @click="goBack"
+      />
+      <h1 class="text-h4 ml-2">
+        {{ isEdit ? 'Edit Item' : 'New Item' }}
+      </h1>
+    </div>
+
+    <v-card
+      v-if="!loading"
+      max-width="720"
+      class="mx-auto"
+    >
+      <app-server-validation-form
+        :endpoint="endpoint"
+        :method="method"
+        :data="form"
+        :success-message="isEdit ? 'Item updated' : 'Item created'"
+        @success="onSuccess"
+      >
+        <template #default="{ submit, loading: submitting, getErrors }">
+          <v-card-text>
+            <v-text-field
+              v-model="form.name"
+              label="Name"
+              :error-messages="getErrors('name')"
+              :rules="[rules.required()]"
+            />
+
+            <v-textarea
+              v-model="form.description"
+              label="Description"
+              rows="3"
+              auto-grow
+              :error-messages="getErrors('description')"
+            />
+
+            <v-row>
+              <v-col
+                cols="12"
+                md="6"
+              >
+                <v-select
+                  v-model="form.status"
+                  label="Status"
+                  :items="statusOptions"
+                  :error-messages="getErrors('status')"
+                  :rules="[rules.required()]"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                md="6"
+              >
+                <v-text-field
+                  v-model.number="form.priority"
+                  label="Priority (1-5)"
+                  type="number"
+                  min="1"
+                  max="5"
+                  :error-messages="getErrors('priority')"
+                  :rules="[rules.required()]"
+                />
+              </v-col>
+            </v-row>
+
+            <v-row>
+              <v-col
+                cols="12"
+                md="6"
+              >
+                <app-date-input
+                  v-model="form.due_date"
+                  label="Due date"
+                  :error-messages="getErrors('due_date')"
+                  clearable
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                md="6"
+              >
+                <app-auto-complete
+                  v-model="form.owner_id"
+                  endpoint="users"
+                  label="Owner"
+                  :item-title="(u: any) => u.full_name"
+                  :item-value="(u: any) => u.id"
+                  :error-messages="getErrors('owner_id')"
+                  clearable
+                />
+              </v-col>
+            </v-row>
+          </v-card-text>
+
+          <v-card-actions>
+            <v-spacer />
+            <v-btn
+              :disabled="submitting"
+              @click="goBack"
+            >
+              Cancel
+            </v-btn>
+            <v-btn
+              color="primary"
+              :loading="submitting"
+              @click="submit"
+            >
+              {{ isEdit ? 'Save' : 'Create' }}
+            </v-btn>
+          </v-card-actions>
+        </template>
+      </app-server-validation-form>
+    </v-card>
+
+    <v-progress-circular
+      v-else
+      indeterminate
+      class="d-block mx-auto mt-12"
+    />
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue"
+import validators from "@/mixins/validators"
+
+interface ItemForm {
+  name:        string
+  description: string
+  status:      string
+  priority:    number
+  due_date:    string | null
+  owner_id:    number | null
+}
+
+const blankForm = (): ItemForm => ({
+  name:        "",
+  description: "",
+  status:      "active",
+  priority:    3,
+  due_date:    null,
+  owner_id:    null,
+})
+
+export default defineComponent({
+  mixins: [validators],
+  data() {
+    return {
+      form:    blankForm(),
+      loading: false,
+      statusOptions: [
+        { title: "Draft",    value: "draft" },
+        { title: "Active",   value: "active" },
+        { title: "Archived", value: "archived" },
+      ],
+    }
+  },
+  computed: {
+    isEdit(): boolean {
+      return !!this.$route.params.id
+    },
+    endpoint(): string {
+      return this.isEdit ? `/items/${this.$route.params.id}` : "/items"
+    },
+    method(): string {
+      return this.isEdit ? "patch" : "post"
+    },
+  },
+  async mounted() {
+    if (this.isEdit) {
+      await this.loadItem()
+    }
+  },
+  methods: {
+    async loadItem() {
+      this.loading = true
+      const { data } = await this.$http.get(`/items/${this.$route.params.id}`).catch(e => e)
+      this.loading = false
+      if (!data) return
+      this.form = {
+        name:        data.name        ?? "",
+        description: data.description ?? "",
+        status:      data.status      ?? "active",
+        priority:    data.priority    ?? 3,
+        due_date:    data.due_date    ?? null,
+        owner_id:    data.owner_id    ?? null,
+      }
+    },
+    onSuccess() {
+      this.$router.push(this.$routeTo(this.ROUTES.ITEMS_LIST))
+    },
+    goBack() {
+      this.$router.push(this.$routeTo(this.ROUTES.ITEMS_LIST))
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/pages/items/ItemFormPage.vue
+++ b/resources/ts/pages/items/ItemFormPage.vue
@@ -109,7 +109,7 @@
             <v-btn
               color="primary"
               :loading="submitting"
-              @click="submit"
+              @click="trySubmit(submit)"
             >
               {{ isEdit ? 'Save' : 'Create' }}
             </v-btn>
@@ -129,6 +129,9 @@
 <script lang="ts">
 import { defineComponent } from "vue"
 import validators from "@/mixins/validators"
+import AppServerValidationForm from "@/components/AppServerValidationForm.vue"
+import AppDateInput from "@/components/fields/AppDateInput.vue"
+import AppAutoComplete from "@/components/fields/AppAutoComplete/AppAutoComplete.vue"
 
 interface ItemForm {
   name:        string
@@ -149,6 +152,7 @@ const blankForm = (): ItemForm => ({
 })
 
 export default defineComponent({
+  components: { AppServerValidationForm, AppDateInput, AppAutoComplete },
   mixins: [validators],
   data() {
     return {
@@ -191,6 +195,13 @@ export default defineComponent({
         due_date:    data.due_date    ?? null,
         owner_id:    data.owner_id    ?? null,
       }
+    },
+    // AppServerValidationForm#submit throws on client-side validation failure
+    // (intentional, so the form can report invalid state). We don't want that
+    // to surface as an unhandled rejection from a button click — the form
+    // itself already shows the per-field errors.
+    async trySubmit(submit: () => Promise<void>) {
+      try { await submit() } catch { /* validation surfaced in form */ }
     },
     onSuccess() {
       this.$router.push(this.$routeTo(this.ROUTES.ITEMS_LIST))

--- a/resources/ts/pages/items/ItemListPage.vue
+++ b/resources/ts/pages/items/ItemListPage.vue
@@ -1,0 +1,122 @@
+<template>
+  <v-container>
+    <div class="d-flex align-center mb-4">
+      <h1 class="text-h4">
+        Items
+      </h1>
+      <v-spacer />
+      <v-btn
+        color="primary"
+        prepend-icon="add"
+        @click="goCreate"
+      >
+        New Item
+      </v-btn>
+    </div>
+
+    <ItemFilterBar
+      v-model="filters"
+      class="mb-4"
+    />
+
+    <app-pagination-table
+      endpoint="items"
+      :headers="headers"
+      :filters="filters"
+      :items-per-page="25"
+      striped-rows
+      @click:row="onRowClick"
+    >
+      <template #[`item.status`]="{ item }">
+        <v-chip
+          :color="statusColor(item.status)"
+          size="small"
+        >
+          {{ item.status }}
+        </v-chip>
+      </template>
+
+      <template #[`item.due_date`]="{ item }">
+        {{ formatDate(item.due_date) }}
+      </template>
+
+      <template #[`item.owner`]="{ item }">
+        {{ item.owner?.full_name ?? '—' }}
+      </template>
+
+      <template #[`item.actions`]="{ item }">
+        <v-btn
+          icon="edit"
+          variant="text"
+          size="small"
+          @click.stop="goEdit(item.id)"
+        />
+        <v-btn
+          icon="delete"
+          variant="text"
+          size="small"
+          color="error"
+          @click.stop="confirmDelete(item)"
+        />
+      </template>
+    </app-pagination-table>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue"
+import ItemFilterBar from "./_components/ItemFilterBar.vue"
+import dayjs from "@/utils/dayjs"
+
+export default defineComponent({
+  components: { ItemFilterBar },
+  data() {
+    return {
+      filters: {
+        search:   "",
+        status:   null as string | null,
+        owner_id: null as number | null,
+      },
+      headers: [
+        { title: "Name",     key: "name",     sortable: true },
+        { title: "Status",   key: "status",   sortable: false },
+        { title: "Priority", key: "priority", sortable: true },
+        { title: "Due",      key: "due_date", sortable: true },
+        { title: "Owner",    key: "owner",    sortable: false },
+        { title: "",         key: "actions",  sortable: false, align: "end" as const, width: 110 },
+      ],
+    }
+  },
+  methods: {
+    statusColor(status: string): string {
+      return ({ active: "success", archived: "grey", draft: "warning" } as Record<string, string>)[status] ?? "grey"
+    },
+    formatDate(date: string | null): string {
+      return date ? dayjs(date).format("MMM D, YYYY") : "—"
+    },
+    goCreate() {
+      this.$router.push(this.$routeTo(this.ROUTES.ITEMS_CREATE))
+    },
+    goEdit(id: number) {
+      this.$router.push(this.$routeTo(this.ROUTES.ITEMS_EDIT, { id }))
+    },
+    onRowClick(_event: PointerEvent, { item }: { item: { id: number } }) {
+      this.goEdit(item.id)
+    },
+    async confirmDelete(item: { id: number; name: string }) {
+      const ok = await this.$confirm(
+        "Delete item?",
+        `"${item.name}" will be archived. This can be undone.`,
+        "error",
+        { buttonTrueText: "Delete", buttonFalseText: "Cancel", buttonTrueColor: "error" },
+      )
+      if (!ok) return
+      await this.$http.delete(`/items/${item.id}`).catch(e => e)
+      // AppPaginationTable refetches on filter mutation; flip a key to force.
+      this.filters = { ...this.filters }
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/pages/items/ItemListPage.vue
+++ b/resources/ts/pages/items/ItemListPage.vue
@@ -20,6 +20,7 @@
     />
 
     <app-pagination-table
+      ref="table"
       endpoint="items"
       :headers="headers"
       :filters="filters"
@@ -66,10 +67,11 @@
 <script lang="ts">
 import { defineComponent } from "vue"
 import ItemFilterBar from "./_components/ItemFilterBar.vue"
+import AppPaginationTable from "@/components/AppPaginationTable.vue"
 import dayjs from "@/utils/dayjs"
 
 export default defineComponent({
-  components: { ItemFilterBar },
+  components: { ItemFilterBar, AppPaginationTable },
   data() {
     return {
       filters: {
@@ -112,8 +114,11 @@ export default defineComponent({
       )
       if (!ok) return
       await this.$http.delete(`/items/${item.id}`).catch(e => e)
-      // AppPaginationTable refetches on filter mutation; flip a key to force.
-      this.filters = { ...this.filters }
+      // AppPaginationTable.reload() is exposed via defineExpose; using a ref
+      // is more reliable than mutating filters, which short-circuits when the
+      // values are identical (deep-equal watcher in AppPaginationTable).
+      const table = this.$refs.table as { reload?: () => Promise<void> } | undefined
+      await table?.reload?.()
     },
   },
 })

--- a/resources/ts/pages/items/_components/ItemFilterBar.vue
+++ b/resources/ts/pages/items/_components/ItemFilterBar.vue
@@ -51,6 +51,7 @@
 <script lang="ts">
 import { defineComponent, type PropType } from "vue"
 import debounce from "lodash.debounce"
+import AppAutoComplete from "@/components/fields/AppAutoComplete/AppAutoComplete.vue"
 
 interface Filters {
   search:   string
@@ -60,6 +61,7 @@ interface Filters {
 
 export default defineComponent({
   name: "ItemFilterBar",
+  components: { AppAutoComplete },
   props: {
     modelValue: {
       type: Object as PropType<Filters>,

--- a/resources/ts/pages/items/_components/ItemFilterBar.vue
+++ b/resources/ts/pages/items/_components/ItemFilterBar.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-card variant="outlined">
+    <v-card-text class="pa-4">
+      <v-row dense>
+        <v-col
+          cols="12"
+          md="5"
+        >
+          <v-text-field
+            v-model="search"
+            label="Search name or description"
+            prepend-inner-icon="search"
+            density="comfortable"
+            hide-details
+            clearable
+          />
+        </v-col>
+        <v-col
+          cols="6"
+          md="3"
+        >
+          <v-select
+            v-model="status"
+            :items="statusOptions"
+            label="Status"
+            density="comfortable"
+            hide-details
+            clearable
+          />
+        </v-col>
+        <v-col
+          cols="6"
+          md="4"
+        >
+          <app-auto-complete
+            v-model="ownerId"
+            endpoint="users"
+            label="Owner"
+            :item-title="(item: any) => item.full_name"
+            :item-value="(item: any) => item.id"
+            density="comfortable"
+            hide-details
+            clearable
+          />
+        </v-col>
+      </v-row>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue"
+import debounce from "lodash.debounce"
+
+interface Filters {
+  search:   string
+  status:   string | null
+  owner_id: number | null
+}
+
+export default defineComponent({
+  name: "ItemFilterBar",
+  props: {
+    modelValue: {
+      type: Object as PropType<Filters>,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      // Local mirrors of the filter values — search debounces before emit
+      // to avoid one request per keystroke.
+      search:   this.modelValue.search,
+      status:   this.modelValue.status,
+      ownerId:  this.modelValue.owner_id,
+      statusOptions: [
+        { title: "Draft",    value: "draft" },
+        { title: "Active",   value: "active" },
+        { title: "Archived", value: "archived" },
+      ],
+    }
+  },
+  watch: {
+    search: {
+      handler: debounce(function (this: any, v: string) {
+        this.emitFilters({ search: v ?? "" })
+      }, 300),
+    },
+    status(v: string | null) {
+      this.emitFilters({ status: v })
+    },
+    ownerId(v: number | null) {
+      this.emitFilters({ owner_id: v })
+    },
+    modelValue: {
+      deep: true,
+      handler(newVal: Filters) {
+        // Keep local state in sync when parent resets filters externally.
+        this.search  = newVal.search
+        this.status  = newVal.status
+        this.ownerId = newVal.owner_id
+      },
+    },
+  },
+  methods: {
+    emitFilters(patch: Partial<Filters>) {
+      this.$emit("update:modelValue", { ...this.modelValue, ...patch })
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/router/paths.ts
+++ b/resources/ts/router/paths.ts
@@ -11,6 +11,10 @@ export const ROUTES = {
 
   DASHBOARD: "dashboard",
   TEST: "test",
+
+  ITEMS_LIST:   "items.list",
+  ITEMS_CREATE: "items.create",
+  ITEMS_EDIT:   "items.edit",
 }
 
 RouteDesigner.setNotFound("Error404Page").layout('Empty')
@@ -29,6 +33,10 @@ RouteDesigner.group('', function () {
   // Authorized routes
   RouteDesigner.group('', function () {
     RouteDesigner.route("/dashboard", "DashboardPage", ROUTES.DASHBOARD)
+
+    RouteDesigner.route("/items",         "items/ItemListPage", ROUTES.ITEMS_LIST)
+    RouteDesigner.route("/items/new",     "items/ItemFormPage", ROUTES.ITEMS_CREATE)
+    RouteDesigner.route("/items/:id/edit","items/ItemFormPage", ROUTES.ITEMS_EDIT)
   })
     .layout("Default")
     .middleware([Authorization])

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\FileController;
 use App\Http\Controllers\ForgotPasswordController;
+use App\Http\Controllers\ItemController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -22,6 +23,7 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware('auth:sanctum')->group(function () {
         Route::apiResource('users', UserController::class);
+        Route::apiResource('items', ItemController::class);
 
         Route::get('/files/{file}/{size?}', [FileController::class, 'url']);
         Route::get('/files/view/{file}', [FileController::class, 'view']);

--- a/tests/Feature/ItemControllerStoreUpdateDestroyTest.php
+++ b/tests/Feature/ItemControllerStoreUpdateDestroyTest.php
@@ -27,10 +27,10 @@ test('store creates an item with valid data', function () {
     $response = $this->postJson('/api/v1/items', $payload, $this->auth);
 
     $response->assertCreated()
-        ->assertJsonPath('name', 'New thing')
-        ->assertJsonPath('status', 'active')
-        ->assertJsonPath('priority', 4)
-        ->assertJsonPath('owner.id', $owner->id);
+        ->assertJsonPath('data.name', 'New thing')
+        ->assertJsonPath('data.status', 'active')
+        ->assertJsonPath('data.priority', 4)
+        ->assertJsonPath('data.owner.id', $owner->id);
 
     $this->assertDatabaseHas('items', [
         'name'          => 'New thing',
@@ -57,15 +57,15 @@ test('store rejects unknown status', function () {
 });
 
 test('update accepts partial payload', function () {
-    $item = Item::factory()->create(['name' => 'Original', 'priority' => 1]);
+    $item = Item::factory()->ownedBy($this->user->id)->create(['name' => 'Original', 'priority' => 1]);
 
     $response = $this->patchJson("/api/v1/items/{$item->id}", [
         'priority' => 5,
     ], $this->auth);
 
     $response->assertOk()
-        ->assertJsonPath('priority', 5)
-        ->assertJsonPath('name', 'Original');
+        ->assertJsonPath('data.priority', 5)
+        ->assertJsonPath('data.name', 'Original');
 
     $this->assertDatabaseHas('items', [
         'id'            => $item->id,
@@ -75,18 +75,38 @@ test('update accepts partial payload', function () {
 });
 
 test('update validates rules on provided fields', function () {
-    $item = Item::factory()->create();
+    $item = Item::factory()->ownedBy($this->user->id)->create();
 
     $this->patchJson("/api/v1/items/{$item->id}", [
         'priority' => 99,
     ], $this->auth)->assertUnprocessable()->assertJsonValidationErrors('priority');
 });
 
+test('update is forbidden for non-owner', function () {
+    $other = User::factory()->create();
+    $item  = Item::factory()->ownedBy($other->id)->create(['priority' => 1]);
+
+    $this->patchJson("/api/v1/items/{$item->id}", ['priority' => 5], $this->auth)
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('items', ['id' => $item->id, 'priority' => 1]);
+});
+
 test('destroy soft-deletes the item', function () {
-    $item = Item::factory()->create();
+    $item = Item::factory()->ownedBy($this->user->id)->create();
 
     $this->deleteJson("/api/v1/items/{$item->id}", [], $this->auth)
         ->assertNoContent();
 
     $this->assertSoftDeleted('items', ['id' => $item->id]);
+});
+
+test('destroy is forbidden for non-owner', function () {
+    $other = User::factory()->create();
+    $item  = Item::factory()->ownedBy($other->id)->create();
+
+    $this->deleteJson("/api/v1/items/{$item->id}", [], $this->auth)
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('items', ['id' => $item->id, 'deleted_at' => null]);
 });

--- a/tests/Feature/ItemControllerStoreUpdateDestroyTest.php
+++ b/tests/Feature/ItemControllerStoreUpdateDestroyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ItemStatus;
+use App\Models\Item;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user  = User::factory()->create();
+    $this->token = $this->user->createToken('test')->plainTextToken;
+    $this->auth  = ['Authorization' => "Bearer {$this->token}"];
+});
+
+test('store creates an item with valid data', function () {
+    $owner = User::factory()->create();
+
+    $payload = [
+        'name'        => 'New thing',
+        'description' => 'Some details',
+        'status'      => ItemStatus::Active->value,
+        'priority'    => 4,
+        'due_date'    => now()->addDays(7)->toDateString(),
+        'owner_id'    => $owner->id,
+    ];
+
+    $response = $this->postJson('/api/v1/items', $payload, $this->auth);
+
+    $response->assertCreated()
+        ->assertJsonPath('name', 'New thing')
+        ->assertJsonPath('status', 'active')
+        ->assertJsonPath('priority', 4)
+        ->assertJsonPath('owner.id', $owner->id);
+
+    $this->assertDatabaseHas('items', [
+        'name'          => 'New thing',
+        'created_by_id' => $this->user->id,
+        'updated_by_id' => $this->user->id,
+    ]);
+});
+
+test('store validates required fields', function () {
+    $response = $this->postJson('/api/v1/items', [], $this->auth);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['name', 'status', 'priority']);
+});
+
+test('store rejects unknown status', function () {
+    $response = $this->postJson('/api/v1/items', [
+        'name'     => 'X',
+        'status'   => 'nonsense',
+        'priority' => 1,
+    ], $this->auth);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('status');
+});
+
+test('update accepts partial payload', function () {
+    $item = Item::factory()->create(['name' => 'Original', 'priority' => 1]);
+
+    $response = $this->patchJson("/api/v1/items/{$item->id}", [
+        'priority' => 5,
+    ], $this->auth);
+
+    $response->assertOk()
+        ->assertJsonPath('priority', 5)
+        ->assertJsonPath('name', 'Original');
+
+    $this->assertDatabaseHas('items', [
+        'id'            => $item->id,
+        'priority'      => 5,
+        'updated_by_id' => $this->user->id,
+    ]);
+});
+
+test('update validates rules on provided fields', function () {
+    $item = Item::factory()->create();
+
+    $this->patchJson("/api/v1/items/{$item->id}", [
+        'priority' => 99,
+    ], $this->auth)->assertUnprocessable()->assertJsonValidationErrors('priority');
+});
+
+test('destroy soft-deletes the item', function () {
+    $item = Item::factory()->create();
+
+    $this->deleteJson("/api/v1/items/{$item->id}", [], $this->auth)
+        ->assertNoContent();
+
+    $this->assertSoftDeleted('items', ['id' => $item->id]);
+});

--- a/tests/Feature/ItemControllerTest.php
+++ b/tests/Feature/ItemControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Item;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user  = User::factory()->create();
+    $this->token = $this->user->createToken('test')->plainTextToken;
+    $this->auth  = ['Authorization' => "Bearer {$this->token}"];
+});
+
+test('unauthenticated requests are rejected', function () {
+    $this->getJson('/api/v1/items')->assertUnauthorized();
+});
+
+test('index returns paginated items', function () {
+    Item::factory()->count(15)->create();
+
+    $response = $this->getJson('/api/v1/items', $this->auth);
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [['id', 'name', 'status', 'priority', 'due_date', 'owner']],
+            'total',
+            'per_page',
+            'current_page',
+            'last_page',
+        ])
+        ->assertJsonPath('total', 15);
+});
+
+test('index filters by status', function () {
+    Item::factory()->active()->count(3)->create();
+    Item::factory()->archived()->count(2)->create();
+
+    $response = $this->getJson('/api/v1/items?status=active', $this->auth);
+
+    $response->assertOk()->assertJsonPath('total', 3);
+});
+
+test('index filters by owner_id', function () {
+    $other = User::factory()->create();
+    Item::factory()->ownedBy($this->user->id)->count(4)->create();
+    Item::factory()->ownedBy($other->id)->count(2)->create();
+
+    $response = $this->getJson("/api/v1/items?owner_id={$this->user->id}", $this->auth);
+
+    $response->assertOk()->assertJsonPath('total', 4);
+});
+
+test('index searches name and description', function () {
+    Item::factory()->create(['name' => 'Unique haystack alpha']);
+    Item::factory()->create(['description' => 'this contains haystack inside']);
+    Item::factory()->create(['name' => 'unrelated']);
+
+    $response = $this->getJson('/api/v1/items?search=haystack', $this->auth);
+
+    $response->assertOk()->assertJsonPath('total', 2);
+});
+
+test('show returns a single item with owner relation loaded', function () {
+    $owner = User::factory()->create(['email' => 'owner@example.test']);
+    $item  = Item::factory()->ownedBy($owner->id)->create(['name' => 'Sample']);
+
+    $response = $this->getJson("/api/v1/items/{$item->id}", $this->auth);
+
+    $response->assertOk()
+        ->assertJsonPath('name', 'Sample')
+        ->assertJsonPath('owner.email', 'owner@example.test');
+});
+
+test('show 404s for missing item', function () {
+    $this->getJson('/api/v1/items/99999', $this->auth)->assertNotFound();
+});

--- a/tests/Feature/ItemControllerTest.php
+++ b/tests/Feature/ItemControllerTest.php
@@ -66,9 +66,10 @@ test('show returns a single item with owner relation loaded', function () {
 
     $response = $this->getJson("/api/v1/items/{$item->id}", $this->auth);
 
+    // JsonResource wraps single-record responses in `data` by default.
     $response->assertOk()
-        ->assertJsonPath('name', 'Sample')
-        ->assertJsonPath('owner.email', 'owner@example.test');
+        ->assertJsonPath('data.name', 'Sample')
+        ->assertJsonPath('data.owner.email', 'owner@example.test');
 });
 
 test('show 404s for missing item', function () {


### PR DESCRIPTION
## Summary

A complete reference implementation of an `Item` CRUD resource that exercises every layer of the template's patterns: migration with `whoDidIt()` + soft deletes → Eloquent model with `scopeFilter` + enum cast → factory with state helpers → Store/Update FormRequests with `sometimes` semantics → API Resource with `whenLoaded` → thin controller with `vuetifyPaginate()` → routes under `auth:sanctum` → Vue list page with `AppPaginationTable` + debounced filter bar → form page using `AppServerValidationForm` for both create and edit → Pest 4 Feature tests covering auth gating, pagination, filters, validation, WhoDidIt audit columns, and soft delete.

Plus `docs/Conventions.md` — an 11-layer flow doc that points at each file in this PR as the canonical reference for AI agents (and humans) building new resources.

## Files added

**Backend:**
- `database/migrations/2026_05_14_120000_create_items_table.php`
- `app/Enums/ItemStatus.php`
- `app/Models/Item.php`
- `database/factories/ItemFactory.php`
- `app/Http/Requests/StoreItemRequest.php` + `UpdateItemRequest.php`
- `app/Http/Resources/ItemResource.php`
- `app/Http/Controllers/ItemController.php`
- `tests/Feature/ItemControllerTest.php`
- `tests/Feature/ItemControllerStoreUpdateDestroyTest.php`

**Frontend:**
- `resources/ts/pages/items/ItemListPage.vue`
- `resources/ts/pages/items/_components/ItemFilterBar.vue`
- `resources/ts/pages/items/ItemFormPage.vue`

**Docs:**
- `docs/Conventions.md`

**Modified:**
- `routes/api.php` (one line)
- `resources/ts/router/paths.ts` (3 ROUTES + 3 route entries)
- `resources/ts/pages/DashboardPage.vue` (Items button)

## What this demonstrates

| Layer | Worth copying because |
| --- | --- |
| Migration | `whoDidIt()` + `softDeletes()` standard for user-editable entities |
| Model | HasFactory + SoftDeletes + WhoDidIt traits, enum cast, BelongsTo, `scopeFilter(array)` |
| Enum | `label()` + `options()` for v-select consumption |
| Factory | Named states (`active()`, `archived()`, `ownedBy(id)`) |
| FormRequests | Store has `required`; Update has `sometimes, required` for partial PATCH |
| Resource | ISO 8601 dates, `whenLoaded()` |
| Controller | 1-3 lines per action, the canonical template |
| Tests | Pest 4 with Sanctum, factories, `assertDatabaseHas`, `assertSoftDeleted` |
| List page | `AppPaginationTable` + slot overrides + actions column |
| Filter bar | Debounced search, status select, owner AppAutoComplete |
| Form page | ONE component for create + edit (branches on `$route.params.id`), `AppServerValidationForm` slot props |

## Test plan

- [ ] `composer ci` passes
- [ ] `docker compose exec $DOCKER_ROUTER php artisan migrate` succeeds
- [ ] `pest --filter Item` — 16+ tests pass
- [ ] Log in, click "Items" on dashboard — list page loads
- [ ] Click "New Item", fill form, save → redirects to list with new row
- [ ] Edit row → fields prefilled, save works
- [ ] Delete row → confirm dialog, row disappears, `deleted_at` set
- [ ] Filter bar: search debounces, status narrows results, owner autocomplete fetches users
- [ ] `composer typescript` regenerates types without errors

## Not in this PR (deferred)

- A `UserMiniResource` (currently owner embed uses full `AuthUserResource`)
- Per-record authorization Policy (no permission system in template yet)
- File attachments on Items
- Wayfinder TS-type regeneration — run `composer typescript` after merge