### PR TITLE
feat(kit): cross-project component & composable kit

### DIFF
--- a/docs/Kit.md
+++ b/docs/Kit.md
@@ -1,0 +1,101 @@
+# Cross-Project Component Kit
+
+Catalog of the small-but-everywhere components and composables shipped in the template. None are required; pick what fits the project.
+
+> **AI agents:** before building a new component that feels "common," check this list first. The 30-second copy-paste from here beats a new bespoke component every time.
+
+## Components (`resources/ts/components/`)
+
+| Component | One-liner | Use for |
+| --- | --- | --- |
+| `AppPageHeader` | Title + subtitle + breadcrumbs + actions slot. | The top of every page. |
+| `AppStatusBadge` | v-chip with built-in color/icon map for the dozen statuses common across apps. | Lists, detail pages, anywhere status is shown. |
+| `AppTimeAgo` | "2 minutes ago" with hover-tooltip for exact timestamp; auto-refreshes. | Anywhere a timestamp is shown. |
+| `AppMoneyDisplay` | Locale-aware currency formatting, tabular numerals, negative styling. | Anywhere money is shown. |
+| `AppCopyableField` | Inline value + copy-to-clipboard with morph-to-check feedback. | IDs, tokens, share URLs, hashes. |
+| `AppInfoTooltip` | `?` icon with hover/focus/click tooltip, keyboard-accessible. | Inline help on form labels and table headers. |
+| `AppFilterChips` | Active filters rendered as removable chips with "Clear all". | Top of any list page using filters. |
+| `AppConfirmActionButton` | Button that opens `$confirm` then runs the action with loading state. | Every destructive action. |
+| `AppImpersonationBanner` | Sticky "Stop impersonating" banner; pairs with existing backend impersonation endpoints. | Admin areas where staff acts as users. |
+| `AppNotificationsBell` | Bell + unread badge + dropdown of recent notifications. | App-bar slot. |
+| `AppWizardSteps` | Multi-step form scaffold with valid-per-step gating. | Onboarding, CSV import, checkout, multi-section forms. |
+| `AppInlineEditField` | Click value to edit; Enter/blur saves, Escape cancels; async save support. | Editable cells / quick admin tweaks. |
+| `AppDateRangePicker` | Start + end date inputs + preset chips (Today / Last 30 / YTD / etc.). | Reports, log views, transaction filters. |
+
+## Layouts (`resources/ts/layouts/`)
+
+| Layout | One-liner |
+| --- | --- |
+| `AdminLayout` | App bar + responsive nav drawer + user menu + slots for everything. |
+
+## Composables (`resources/ts/composables/`)
+
+| Composable | Signature | Use for |
+| --- | --- | --- |
+| `useApi<T>(endpoint, opts?)` | `{ data, error, loading, refresh }` | Fetch-on-mount pages with reactive state. |
+| `useFilters(initial, opts?)` | `{ filters, reset, isActive }` | URL-synced filter state on any list page. |
+| `useSelection<K>()` | `{ selectedKeys, count, isSelected, toggle, toggleAll, ... }` | Multi-select tables with bulk actions. |
+| `useDocumentTitle(title, opts?)` | (void) | Set document.title for the page's lifetime, with auto-restore. |
+
+## Patterns demonstrated together
+
+A typical list page in any project on this stack:
+
+```vue
+<template>
+  <AppPageHeader title="Items" :breadcrumbs="crumbs">
+    <template #actions>
+      <v-btn color="primary" @click="goCreate">New</v-btn>
+    </template>
+  </AppPageHeader>
+
+  <ItemFilterBar v-model="filters" />
+  <AppFilterChips v-model="filters" :labels="{ owner_id: 'Owner' }" />
+
+  <AppPaginationTable endpoint="items" :filters="filters">
+    <template #[`item.status`]="{ item }">
+      <AppStatusBadge :value="item.status" />
+    </template>
+    <template #[`item.created_at`]="{ item }">
+      <AppTimeAgo :value="item.created_at" />
+    </template>
+    <template #[`item.amount`]="{ item }">
+      <AppMoneyDisplay :value="item.amount" />
+    </template>
+    <template #[`item.actions`]="{ item }">
+      <AppConfirmActionButton
+        text="Delete"
+        :confirm-message="`Delete &quot;${item.name}&quot;?`"
+        @confirmed="destroy(item)"
+      />
+    </template>
+  </AppPaginationTable>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue"
+import AppPageHeader from "@/components/AppPageHeader.vue"
+import AppStatusBadge from "@/components/AppStatusBadge.vue"
+import AppTimeAgo from "@/components/AppTimeAgo.vue"
+import AppMoneyDisplay from "@/components/AppMoneyDisplay.vue"
+import AppFilterChips from "@/components/AppFilterChips.vue"
+import AppConfirmActionButton from "@/components/AppConfirmActionButton.vue"
+import { useFilters } from "@/composables/useFilters"
+import { useDocumentTitle } from "@/composables/useDocumentTitle"
+
+export default defineComponent({
+  components: {
+    AppPageHeader, AppStatusBadge, AppTimeAgo, AppMoneyDisplay,
+    AppFilterChips, AppConfirmActionButton,
+  },
+  setup() {
+    useDocumentTitle("Items")
+    const { filters } = useFilters({ search: "", status: null, owner_id: null })
+    return { filters }
+  },
+  // ...
+})
+</script>
+```
+
+The 5 components + 2 composables in that snippet remove ~150 lines of boilerplate that would otherwise live in the page itself.

--- a/resources/ts/components/AppConfirmActionButton.vue
+++ b/resources/ts/components/AppConfirmActionButton.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-btn
+    :color="color"
+    :variant="variant"
+    :size="size"
+    :prepend-icon="prependIcon"
+    :append-icon="appendIcon"
+    :loading="loading"
+    :disabled="disabled"
+    @click="onClick"
+  >
+    <slot>{{ text }}</slot>
+  </v-btn>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue"
+import { $confirm } from "@/plugins/confirm"
+
+const props = withDefaults(defineProps<{
+  /** Button label — overridable via default slot. */
+  text?:           string
+  /** Confirm dialog title. */
+  confirmTitle?:   string
+  /** Confirm dialog body. */
+  confirmMessage?: string
+  /** Confirm primary button label, color, and icon. */
+  confirmText?:    string
+  confirmColor?:   string
+  /** Set to false to bypass the dialog (useful when caller toggles it conditionally). */
+  requireConfirm?: boolean
+  /** Vuetify v-btn passthroughs. */
+  color?:          string
+  variant?:        "elevated" | "flat" | "tonal" | "outlined" | "text" | "plain"
+  size?:           "x-small" | "small" | "default" | "large" | "x-large"
+  prependIcon?:    string
+  appendIcon?:     string
+  disabled?:       boolean
+}>(), {
+  text:           "Delete",
+  confirmTitle:   "Are you sure?",
+  confirmMessage: "This action cannot be undone.",
+  confirmText:    "Confirm",
+  confirmColor:   "error",
+  requireConfirm: true,
+  color:          "error",
+  variant:        "tonal",
+  size:           "default",
+  prependIcon:    undefined,
+  appendIcon:     undefined,
+  disabled:       false,
+})
+
+const emit = defineEmits<{
+  /** Fires after the user confirms (or immediately if requireConfirm=false). */
+  confirmed:      []
+  /** Fires when the user cancels the confirm dialog. */
+  cancelled:      []
+}>()
+
+const loading = ref(false)
+
+/**
+ * Use this from the parent: bind @confirmed to your action; while the action
+ * runs, set `:loading="true"` via a child ref, OR don't pass loading at all
+ * and rely on the awaited handler via `runAsync` exposed below.
+ */
+async function onClick() {
+  if (props.requireConfirm) {
+    const ok = await $confirm(
+      props.confirmTitle,
+      props.confirmMessage,
+      "warning",
+      {
+        buttonTrueText:  props.confirmText,
+        buttonTrueColor: props.confirmColor,
+        buttonFalseText: "Cancel",
+      },
+    )
+    if (!ok) {
+      emit("cancelled")
+      return
+    }
+  }
+  emit("confirmed")
+}
+
+/** Parent can call this to wrap an async action with the loading state. */
+async function runAsync<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  loading.value = true
+  try {
+    return await fn()
+  } finally {
+    loading.value = false
+  }
+}
+
+defineExpose({ runAsync, setLoading: (v: boolean) => { loading.value = v } })
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/components/AppCopyableField.vue
+++ b/resources/ts/components/AppCopyableField.vue
@@ -1,0 +1,89 @@
+<template>
+  <span class="app-copyable d-inline-flex align-center ga-1">
+    <span
+      v-if="!hideValue"
+      class="app-copyable__value"
+      :class="{ 'app-copyable__value--mono': monospace }"
+    >
+      <slot>{{ display }}</slot>
+    </span>
+    <v-tooltip
+      location="top"
+      :text="tooltipText"
+    >
+      <template #activator="{ props: activatorProps }">
+        <v-btn
+          v-bind="activatorProps"
+          :icon="copied ? 'check' : 'content_copy'"
+          :color="copied ? 'success' : undefined"
+          variant="text"
+          size="x-small"
+          density="comfortable"
+          :aria-label="ariaLabel"
+          @click="onCopy"
+        />
+      </template>
+    </v-tooltip>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue"
+
+const props = withDefaults(defineProps<{
+  /** The value that gets copied. Falls back to slot text content if omitted. */
+  value?:     string | number | null
+  /** When true, only the copy button renders. Useful next to existing labels. */
+  hideValue?: boolean
+  /** Tooltip on the button before clicking. */
+  tooltip?:   string
+  /** Tooltip after successful copy. Auto-reverts after 1.5s. */
+  copiedTooltip?: string
+  /** Render the value in a monospace font (useful for IDs, tokens, hashes). */
+  monospace?: boolean
+  /** Hidden a11y label for the button. */
+  ariaLabel?: string
+}>(), {
+  value:         undefined,
+  hideValue:     false,
+  tooltip:       "Copy",
+  copiedTooltip: "Copied!",
+  monospace:     false,
+  ariaLabel:     "Copy to clipboard",
+})
+
+const copied = ref(false)
+const display     = computed(() => props.value ?? "")
+const tooltipText = computed(() => copied.value ? props.copiedTooltip : props.tooltip)
+
+async function onCopy() {
+  const text = String(props.value ?? "")
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+    } else {
+      // Fallback for non-https/old browsers
+      const ta = document.createElement("textarea")
+      ta.value = text
+      ta.style.position = "fixed"
+      ta.style.opacity = "0"
+      document.body.appendChild(ta)
+      ta.select()
+      document.execCommand("copy")
+      document.body.removeChild(ta)
+    }
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 1500)
+  } catch {
+    // Silently fail — caller can listen on @copy:error if needed.
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.app-copyable {
+  &__value--mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+}
+</style>

--- a/resources/ts/components/AppDateRangePicker.vue
+++ b/resources/ts/components/AppDateRangePicker.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="app-date-range">
+    <div class="d-flex flex-wrap ga-2 mb-2">
+      <v-chip
+        v-for="p in presets"
+        :key="p.label"
+        :color="isActivePreset(p.label) ? 'primary' : undefined"
+        :variant="isActivePreset(p.label) ? 'flat' : 'outlined'"
+        size="small"
+        @click="applyPreset(p)"
+      >
+        {{ p.label }}
+      </v-chip>
+    </div>
+
+    <div class="d-flex flex-wrap ga-3 align-start">
+      <app-date-input
+        v-model="startValue"
+        :label="startLabel"
+        :error-messages="errorMessages"
+        clearable
+        density="compact"
+        hide-details="auto"
+        style="min-width: 180px;"
+      />
+      <app-date-input
+        v-model="endValue"
+        :label="endLabel"
+        :error-messages="errorMessages"
+        clearable
+        density="compact"
+        hide-details="auto"
+        style="min-width: 180px;"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, watch } from "vue"
+import dayjs from "@/utils/dayjs"
+
+export interface DateRange {
+  start: string | null
+  end:   string | null
+}
+
+interface Preset {
+  label: string
+  start: () => dayjs.Dayjs
+  end:   () => dayjs.Dayjs
+}
+
+const props = withDefaults(defineProps<{
+  modelValue:  DateRange
+  startLabel?: string
+  endLabel?:   string
+  /** Disable individual preset chips by label. Useful per project. */
+  hidePresets?: string[]
+}>(), {
+  startLabel:  "From",
+  endLabel:    "To",
+  hidePresets: () => [],
+})
+
+const emit = defineEmits<{
+  "update:modelValue": [value: DateRange]
+}>()
+
+const startValue = computed({
+  get: () => props.modelValue.start,
+  set: (v) => emit("update:modelValue", { start: v, end: props.modelValue.end }),
+})
+
+const endValue = computed({
+  get: () => props.modelValue.end,
+  set: (v) => emit("update:modelValue", { start: props.modelValue.start, end: v }),
+})
+
+const allPresets: Preset[] = [
+  { label: "Today",        start: () => dayjs().startOf("day"),  end: () => dayjs().endOf("day") },
+  { label: "Yesterday",    start: () => dayjs().subtract(1, "day").startOf("day"), end: () => dayjs().subtract(1, "day").endOf("day") },
+  { label: "This week",    start: () => dayjs().startOf("week"), end: () => dayjs().endOf("week") },
+  { label: "Last 7 days",  start: () => dayjs().subtract(6, "day").startOf("day"), end: () => dayjs().endOf("day") },
+  { label: "Last 30 days", start: () => dayjs().subtract(29, "day").startOf("day"), end: () => dayjs().endOf("day") },
+  { label: "This month",   start: () => dayjs().startOf("month"), end: () => dayjs().endOf("month") },
+  { label: "Last month",   start: () => dayjs().subtract(1, "month").startOf("month"), end: () => dayjs().subtract(1, "month").endOf("month") },
+  { label: "YTD",          start: () => dayjs().startOf("year"), end: () => dayjs().endOf("day") },
+]
+
+const presets = computed(() => allPresets.filter(p => !props.hidePresets.includes(p.label)))
+
+function applyPreset(p: Preset) {
+  emit("update:modelValue", {
+    start: p.start().format("YYYY-MM-DD"),
+    end:   p.end().format("YYYY-MM-DD"),
+  })
+}
+
+function isActivePreset(label: string): boolean {
+  const p = allPresets.find(x => x.label === label)
+  if (!p) return false
+  return (
+    props.modelValue.start === p.start().format("YYYY-MM-DD") &&
+    props.modelValue.end   === p.end().format("YYYY-MM-DD")
+  )
+}
+
+// Validation: end must not precede start. Surfaces in both fields' error messages.
+const errorMessages = computed(() => {
+  const s = props.modelValue.start
+  const e = props.modelValue.end
+  if (s && e && dayjs(e).isBefore(dayjs(s), "day")) {
+    return ["End date must be on or after the start date"]
+  }
+  return []
+})
+
+// If user picks an end before start, no auto-correct — let them see the message
+// and decide which one to change. Keep this watch as a hook for projects that
+// want to coerce: just override emit('update:modelValue').
+watch(errorMessages, () => { /* hook for parent override */ })
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/components/AppDateRangePicker.vue
+++ b/resources/ts/components/AppDateRangePicker.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watch } from "vue"
+import { computed } from "vue"
 import dayjs from "@/utils/dayjs"
 
 export interface DateRange {
@@ -116,10 +116,9 @@ const errorMessages = computed(() => {
   return []
 })
 
-// If user picks an end before start, no auto-correct — let them see the message
-// and decide which one to change. Keep this watch as a hook for projects that
-// want to coerce: just override emit('update:modelValue').
-watch(errorMessages, () => { /* hook for parent override */ })
+// If user picks an end before start, no auto-correct — show the message and
+// let the user decide which one to change. Parents that want to coerce can
+// react to update:modelValue themselves.
 </script>
 
 <style lang="scss" scoped></style>

--- a/resources/ts/components/AppFilterChips.vue
+++ b/resources/ts/components/AppFilterChips.vue
@@ -1,0 +1,97 @@
+<template>
+  <div
+    v-if="activeFilters.length"
+    class="app-filter-chips d-flex flex-wrap ga-2 align-center"
+  >
+    <span class="text-caption text-medium-emphasis">
+      Filters:
+    </span>
+    <v-chip
+      v-for="f in activeFilters"
+      :key="f.key"
+      closable
+      size="small"
+      variant="tonal"
+      @click:close="clear(f.key)"
+    >
+      <strong class="me-1">{{ f.label }}:</strong> {{ f.display }}
+    </v-chip>
+    <v-btn
+      v-if="activeFilters.length > 1"
+      variant="text"
+      size="x-small"
+      @click="clearAll"
+    >
+      Clear all
+    </v-btn>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue"
+
+type FilterValue = string | number | boolean | null | undefined
+
+const props = defineProps<{
+  /** The filters object — pair this with v-model. */
+  modelValue: Record<string, FilterValue | FilterValue[]>
+  /** Optional human labels per key (e.g. { owner_id: "Owner" }). Defaults to the key. */
+  labels?:    Record<string, string>
+  /**
+   * Optional formatter per key (e.g. for owner_id → owner full_name).
+   * Receives the raw value; return a string for display.
+   */
+  formatters?: Record<string, (value: FilterValue | FilterValue[]) => string>
+  /** Keys to ignore (never show as chips, e.g. internal pagination). */
+  ignoreKeys?: string[]
+}>()
+
+const emit = defineEmits<{
+  "update:modelValue": [Record<string, FilterValue | FilterValue[]>]
+}>()
+
+const activeFilters = computed(() => {
+  const ignore = new Set(props.ignoreKeys ?? [])
+  return Object.entries(props.modelValue ?? {})
+    .filter(([key, value]) => {
+      if (ignore.has(key)) return false
+      if (value === null || value === undefined || value === "") return false
+      if (Array.isArray(value) && value.length === 0) return false
+      return true
+    })
+    .map(([key, value]) => ({
+      key,
+      label:   props.labels?.[key] ?? humanize(key),
+      display: props.formatters?.[key]?.(value) ?? formatDefault(value),
+    }))
+})
+
+function clear(key: string) {
+  const next = { ...props.modelValue, [key]: defaultClearValue(props.modelValue[key]) }
+  emit("update:modelValue", next)
+}
+
+function clearAll() {
+  const next: Record<string, FilterValue | FilterValue[]> = { ...props.modelValue }
+  for (const f of activeFilters.value) next[f.key] = defaultClearValue(props.modelValue[f.key])
+  emit("update:modelValue", next)
+}
+
+function defaultClearValue(prev: FilterValue | FilterValue[]): FilterValue | FilterValue[] {
+  if (Array.isArray(prev)) return []
+  if (typeof prev === "boolean") return false
+  if (typeof prev === "string")  return ""
+  return null
+}
+
+function formatDefault(value: FilterValue | FilterValue[]): string {
+  if (Array.isArray(value)) return value.join(", ")
+  return String(value)
+}
+
+function humanize(s: string): string {
+  return s.replace(/[_-]+/g, " ").replace(/\b\w/g, c => c.toUpperCase())
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/components/AppImpersonationBanner.vue
+++ b/resources/ts/components/AppImpersonationBanner.vue
@@ -1,0 +1,72 @@
+<template>
+  <v-banner
+    v-if="visible"
+    color="warning"
+    icon="visibility"
+    sticky
+    lines="one"
+    density="compact"
+    class="app-impersonation-banner"
+  >
+    <v-banner-text>
+      <strong>Impersonating</strong>
+      <template v-if="impersonatingAs">
+        as <strong>{{ impersonatingAs }}</strong>
+      </template>
+      <template v-if="originalUser">
+        (you are signed in as <strong>{{ originalUser }}</strong>)
+      </template>
+    </v-banner-text>
+    <template #actions>
+      <v-btn
+        variant="tonal"
+        :loading="loading"
+        @click="onStop"
+      >
+        Stop impersonating
+      </v-btn>
+    </template>
+  </v-banner>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue"
+
+const props = defineProps<{
+  visible:           boolean
+  impersonatingAs?:  string
+  originalUser?:     string
+}>()
+
+const emit = defineEmits<{
+  /**
+   * Fires when the user clicks "Stop impersonating". Parent should call
+   * `$auth.stopImpersonating()` and then await its resolution; bind
+   * :loading="loading" on this component (via template ref) or simply
+   * v-if=false the banner once the API call resolves.
+   */
+  stop: []
+}>()
+
+void props // suppress unused
+const loading = ref(false)
+
+async function onStop() {
+  loading.value = true
+  emit("stop")
+  // Parent owns the API call; reset loading after a beat so a re-render
+  // from the banner-disappearing doesn't leave it spinning.
+  setTimeout(() => { loading.value = false }, 3000)
+}
+
+defineExpose({ setLoading: (v: boolean) => { loading.value = v } })
+</script>
+
+<style lang="scss" scoped>
+.app-impersonation-banner {
+  // Pin to the very top of the viewport so it's always visible during
+  // an impersonation session — defends against staff doing actions on
+  // behalf of a user without noticing.
+  z-index: 2000;
+}
+</style>

--- a/resources/ts/components/AppImpersonationBanner.vue
+++ b/resources/ts/components/AppImpersonationBanner.vue
@@ -32,7 +32,7 @@
 <script lang="ts" setup>
 import { ref } from "vue"
 
-const props = defineProps<{
+defineProps<{
   visible:           boolean
   impersonatingAs?:  string
   originalUser?:     string
@@ -40,23 +40,19 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   /**
-   * Fires when the user clicks "Stop impersonating". Parent should call
-   * `$auth.stopImpersonating()` and then await its resolution; bind
-   * :loading="loading" on this component (via template ref) or simply
-   * v-if=false the banner once the API call resolves.
+   * Fires when the user clicks "Stop impersonating". The banner sets its own
+   * loading state to true; the parent owns the API call and is responsible
+   * for either v-if=false-ing the banner on success or calling setLoading(false)
+   * on failure so the button stops spinning.
    */
   stop: []
 }>()
 
-void props // suppress unused
 const loading = ref(false)
 
-async function onStop() {
+function onStop() {
   loading.value = true
   emit("stop")
-  // Parent owns the API call; reset loading after a beat so a re-render
-  // from the banner-disappearing doesn't leave it spinning.
-  setTimeout(() => { loading.value = false }, 3000)
 }
 
 defineExpose({ setLoading: (v: boolean) => { loading.value = v } })

--- a/resources/ts/components/AppInfoTooltip.vue
+++ b/resources/ts/components/AppInfoTooltip.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-tooltip
+    :location="location"
+    :max-width="maxWidth"
+    open-on-focus
+    open-on-click
+  >
+    <template #activator="{ props: activatorProps }">
+      <v-icon
+        v-bind="activatorProps"
+        :icon="icon"
+        :size="size"
+        class="app-info-tooltip"
+        :aria-label="ariaLabel"
+        tabindex="0"
+      />
+    </template>
+    <slot>{{ text }}</slot>
+  </v-tooltip>
+</template>
+
+<script lang="ts" setup>
+withDefaults(defineProps<{
+  /** Tooltip body. Override via default slot for rich content. */
+  text?:      string
+  icon?:      string
+  size?:      "x-small" | "small" | "default" | "large" | "x-large" | number
+  location?:  "top" | "bottom" | "start" | "end"
+  maxWidth?:  number | string
+  ariaLabel?: string
+}>(), {
+  text:      undefined,
+  icon:      "help_outline",
+  size:      "small",
+  location:  "top",
+  maxWidth:  320,
+  ariaLabel: "More information",
+})
+</script>
+
+<style lang="scss" scoped>
+.app-info-tooltip {
+  cursor: help;
+  opacity: 0.65;
+  &:hover, &:focus {
+    opacity: 1;
+  }
+  // Make the focus ring visible for keyboard users.
+  &:focus-visible {
+    outline: 2px solid rgb(var(--v-theme-primary));
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
+}
+</style>

--- a/resources/ts/components/AppInlineEditField.vue
+++ b/resources/ts/components/AppInlineEditField.vue
@@ -26,8 +26,8 @@
       @keydown.enter.prevent="startEdit"
       @keydown.space.prevent="startEdit"
     >
-      <slot :value="display">
-        {{ display || placeholder || "—" }}
+      <slot :value="modelValue">
+        {{ modelValue || placeholder || "—" }}
       </slot>
       <v-icon
         size="x-small"
@@ -67,11 +67,14 @@ const saving       = ref(false)
 const draft        = ref<string | number | null>(props.modelValue)
 const errorMessage = ref<string>("")
 const inputRef     = ref<HTMLInputElement | null>(null)
-const display      = ref(props.modelValue)
+// Track the draft value whose save attempt failed so a subsequent blur on
+// the same value doesn't re-fire the failing API call.
+const lastFailedDraft = ref<string | number | null | undefined>(undefined)
 
 async function startEdit() {
   draft.value = props.modelValue
   errorMessage.value = ""
+  lastFailedDraft.value = undefined
   editing.value = true
   await nextTick()
   ;(inputRef.value as unknown as { focus?: () => void })?.focus?.()
@@ -79,20 +82,26 @@ async function startEdit() {
 
 async function save() {
   if (!editing.value) return
+  if (saving.value) return
   if (draft.value === props.modelValue) {
     editing.value = false
     return
   }
+  // After a save failure we stay in editing mode for correction. A subsequent
+  // blur on the same draft must not re-hit the API — only retry when the user
+  // edits the value again.
+  if (errorMessage.value && draft.value === lastFailedDraft.value) return
 
   saving.value = true
   errorMessage.value = ""
   try {
     if (props.onSave) await props.onSave(draft.value)
     emit("update:modelValue", draft.value)
-    display.value = draft.value
     editing.value = false
+    lastFailedDraft.value = undefined
   } catch (e) {
     errorMessage.value = e instanceof Error ? e.message : "Could not save"
+    lastFailedDraft.value = draft.value
     // stay in editing mode so the user can correct
   } finally {
     saving.value = false

--- a/resources/ts/components/AppInlineEditField.vue
+++ b/resources/ts/components/AppInlineEditField.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="app-inline-edit">
+    <v-text-field
+      v-if="editing"
+      ref="inputRef"
+      v-model="draft"
+      :type="type"
+      :placeholder="placeholder"
+      :rules="rules"
+      :loading="saving"
+      :error-messages="errorMessage ? [errorMessage] : []"
+      density="compact"
+      hide-details="auto"
+      autofocus
+      @keydown.enter.prevent="save"
+      @keydown.escape.prevent="cancel"
+      @blur="save"
+    />
+    <span
+      v-else
+      class="app-inline-edit__display"
+      role="button"
+      tabindex="0"
+      :aria-label="`Edit ${label ?? 'value'}`"
+      @click="startEdit"
+      @keydown.enter.prevent="startEdit"
+      @keydown.space.prevent="startEdit"
+    >
+      <slot :value="display">
+        {{ display || placeholder || "—" }}
+      </slot>
+      <v-icon
+        size="x-small"
+        class="ms-1 app-inline-edit__icon"
+      >
+        edit
+      </v-icon>
+    </span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { nextTick, ref } from "vue"
+
+const props = withDefaults(defineProps<{
+  modelValue:    string | number | null
+  label?:        string
+  placeholder?:  string
+  type?:         "text" | "number" | "email" | "url"
+  rules?:        ((v: unknown) => true | string)[]
+  /** Called on save; should return a Promise. Errors flow into errorMessage. */
+  onSave?:       (value: string | number | null) => Promise<unknown> | unknown
+}>(), {
+  label:       undefined,
+  placeholder: undefined,
+  type:        "text",
+  rules:       () => [],
+  onSave:      undefined,
+})
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string | number | null]
+}>()
+
+const editing      = ref(false)
+const saving       = ref(false)
+const draft        = ref<string | number | null>(props.modelValue)
+const errorMessage = ref<string>("")
+const inputRef     = ref<HTMLInputElement | null>(null)
+const display      = ref(props.modelValue)
+
+async function startEdit() {
+  draft.value = props.modelValue
+  errorMessage.value = ""
+  editing.value = true
+  await nextTick()
+  ;(inputRef.value as unknown as { focus?: () => void })?.focus?.()
+}
+
+async function save() {
+  if (!editing.value) return
+  if (draft.value === props.modelValue) {
+    editing.value = false
+    return
+  }
+
+  saving.value = true
+  errorMessage.value = ""
+  try {
+    if (props.onSave) await props.onSave(draft.value)
+    emit("update:modelValue", draft.value)
+    display.value = draft.value
+    editing.value = false
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : "Could not save"
+    // stay in editing mode so the user can correct
+  } finally {
+    saving.value = false
+  }
+}
+
+function cancel() {
+  draft.value = props.modelValue
+  errorMessage.value = ""
+  editing.value = false
+}
+</script>
+
+<style lang="scss" scoped>
+.app-inline-edit {
+  display: inline-block;
+  min-width: 80px;
+
+  &__display {
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 4px;
+    transition: background-color 0.15s;
+
+    &:hover {
+      background-color: rgba(var(--v-theme-on-surface), 0.06);
+
+      .app-inline-edit__icon {
+        opacity: 1;
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgb(var(--v-theme-primary));
+      outline-offset: 2px;
+    }
+  }
+
+  &__icon {
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+}
+</style>

--- a/resources/ts/components/AppMoneyDisplay.vue
+++ b/resources/ts/components/AppMoneyDisplay.vue
@@ -1,0 +1,58 @@
+<template>
+  <span
+    class="app-money"
+    :class="{ 'app-money--negative': isNegative }"
+  >{{ formatted }}</span>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue"
+
+const props = withDefaults(defineProps<{
+  /** Amount. Can be in major units (dollars) or minor units (cents); flip with `fromCents`. */
+  value:      number | string | null | undefined
+  currency?:  string  // ISO 4217 code, default USD
+  locale?:    string  // BCP-47 tag, default en-US
+  fromCents?: boolean
+  /** Override emptyText for null/NaN. */
+  emptyText?: string
+  /** Force 2 decimal places even when value is whole. */
+  alwaysShowCents?: boolean
+}>(), {
+  currency:        "USD",
+  locale:          "en-US",
+  fromCents:       false,
+  emptyText:       "—",
+  alwaysShowCents: true,
+})
+
+const numeric = computed<number | null>(() => {
+  if (props.value === null || props.value === undefined || props.value === "") return null
+  const n = typeof props.value === "string" ? Number(props.value) : props.value
+  if (Number.isNaN(n)) return null
+  return props.fromCents ? n / 100 : n
+})
+
+const isNegative = computed(() => numeric.value !== null && numeric.value < 0)
+
+const formatted = computed(() => {
+  if (numeric.value === null) return props.emptyText
+  return new Intl.NumberFormat(props.locale, {
+    style:                 "currency",
+    currency:              props.currency,
+    minimumFractionDigits: props.alwaysShowCents ? 2 : 0,
+    maximumFractionDigits: 2,
+  }).format(numeric.value)
+})
+</script>
+
+<style lang="scss" scoped>
+.app-money {
+  // Right-align by default — most money is rendered in tables / right columns.
+  font-variant-numeric: tabular-nums;
+
+  &--negative {
+    color: rgb(var(--v-theme-error));
+  }
+}
+</style>

--- a/resources/ts/components/AppNotificationsBell.vue
+++ b/resources/ts/components/AppNotificationsBell.vue
@@ -1,0 +1,156 @@
+<template>
+  <v-menu
+    :close-on-content-click="false"
+    location="bottom end"
+    transition="slide-y-transition"
+  >
+    <template #activator="{ props: act }">
+      <v-btn
+        v-bind="act"
+        :icon="true"
+        variant="text"
+        :aria-label="unreadCount ? `${unreadCount} unread notifications` : 'Notifications'"
+      >
+        <v-badge
+          :model-value="unreadCount > 0"
+          :content="badgeContent"
+          color="error"
+          location="top end"
+          offset-x="-2"
+          offset-y="-2"
+        >
+          <v-icon>{{ unreadCount ? "notifications_active" : "notifications" }}</v-icon>
+        </v-badge>
+      </v-btn>
+    </template>
+
+    <v-card
+      width="380"
+      max-width="95vw"
+    >
+      <v-card-title class="d-flex align-center pa-3">
+        Notifications
+        <v-spacer />
+        <v-btn
+          v-if="unreadCount > 0"
+          size="small"
+          variant="text"
+          @click="$emit('markAllRead')"
+        >
+          Mark all read
+        </v-btn>
+      </v-card-title>
+
+      <v-divider />
+
+      <div
+        v-if="!notifications.length"
+        class="pa-6 text-center text-medium-emphasis"
+      >
+        <v-icon
+          size="36"
+          class="mb-2"
+        >
+          inbox
+        </v-icon>
+        <div class="text-body-2">
+          You're all caught up.
+        </div>
+      </div>
+
+      <v-list
+        v-else
+        density="compact"
+        max-height="420"
+        class="overflow-y-auto"
+      >
+        <v-list-item
+          v-for="n in notifications"
+          :key="n.id"
+          :class="{ 'app-notif--unread': !n.readAt }"
+          @click="onItemClick(n)"
+        >
+          <template
+            v-if="n.icon"
+            #prepend
+          >
+            <v-icon :color="n.color ?? 'primary'">
+              {{ n.icon }}
+            </v-icon>
+          </template>
+          <v-list-item-title class="text-body-2">
+            {{ n.title }}
+          </v-list-item-title>
+          <v-list-item-subtitle
+            v-if="n.body"
+            class="text-caption text-truncate"
+          >
+            {{ n.body }}
+          </v-list-item-subtitle>
+          <template #append>
+            <span class="text-caption text-medium-emphasis">
+              <AppTimeAgo :value="n.createdAt" />
+            </span>
+          </template>
+        </v-list-item>
+      </v-list>
+
+      <v-divider v-if="notifications.length" />
+      <v-card-actions v-if="notifications.length">
+        <v-btn
+          block
+          variant="text"
+          @click="$emit('viewAll')"
+        >
+          View all
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue"
+import AppTimeAgo from "@/components/AppTimeAgo.vue"
+
+export interface NotificationItem {
+  id:        string | number
+  title:     string
+  body?:     string
+  icon?:     string
+  color?:    string
+  readAt?:   string | null
+  createdAt: string
+}
+
+const props = withDefaults(defineProps<{
+  notifications: NotificationItem[]
+  unreadCount?:  number
+  /** Badge caps at this number for cleaner display. */
+  badgeCap?:     number
+}>(), {
+  unreadCount: 0,
+  badgeCap:    99,
+})
+
+const emit = defineEmits<{
+  /** User clicked a single notification. Caller decides routing / marking. */
+  itemClick:   [item: NotificationItem]
+  markAllRead: []
+  viewAll:     []
+}>()
+
+const badgeContent = computed(() =>
+  props.unreadCount > props.badgeCap ? `${props.badgeCap}+` : String(props.unreadCount),
+)
+
+function onItemClick(item: NotificationItem) {
+  emit("itemClick", item)
+}
+</script>
+
+<style lang="scss" scoped>
+.app-notif--unread {
+  background-color: rgba(var(--v-theme-primary), 0.06);
+}
+</style>

--- a/resources/ts/components/AppPageHeader.vue
+++ b/resources/ts/components/AppPageHeader.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="app-page-header mb-4">
+    <v-breadcrumbs
+      v-if="breadcrumbs?.length || $slots.breadcrumbs"
+      :items="breadcrumbs ?? []"
+      density="compact"
+      class="pa-0 mb-1"
+    >
+      <template
+        v-if="$slots.breadcrumbs"
+        #default
+      >
+        <slot name="breadcrumbs" />
+      </template>
+    </v-breadcrumbs>
+
+    <div class="d-flex flex-wrap align-center ga-3">
+      <v-btn
+        v-if="backTo"
+        :to="backTo"
+        icon="arrow_back"
+        variant="text"
+        size="small"
+        aria-label="Back"
+      />
+
+      <div class="flex-grow-1 min-w-0">
+        <h1
+          class="text-h5 text-md-h4 mb-0"
+          :class="titleClass"
+        >
+          {{ title }}
+        </h1>
+        <p
+          v-if="subtitle"
+          class="text-body-2 text-medium-emphasis mt-1 mb-0"
+        >
+          {{ subtitle }}
+        </p>
+      </div>
+
+      <div
+        v-if="$slots.actions"
+        class="d-flex flex-wrap ga-2 ms-auto"
+      >
+        <slot name="actions" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { RouteLocationRaw } from "vue-router"
+
+export interface Breadcrumb {
+  title:    string
+  to?:      RouteLocationRaw
+  href?:    string
+  disabled?: boolean
+}
+
+withDefaults(defineProps<{
+  title:        string
+  subtitle?:    string
+  breadcrumbs?: Breadcrumb[]
+  /** When set, renders a back-arrow button that navigates to the given route. */
+  backTo?:      RouteLocationRaw
+  /** Extra classes on the h1 — useful for color tweaks per page. */
+  titleClass?:  string
+}>(), {
+  subtitle:    undefined,
+  breadcrumbs: () => [],
+  backTo:      undefined,
+  titleClass:  "",
+})
+</script>
+
+<style lang="scss" scoped>
+.app-page-header :deep(.v-breadcrumbs-item) {
+  padding: 0;
+}
+</style>

--- a/resources/ts/components/AppStatusBadge.vue
+++ b/resources/ts/components/AppStatusBadge.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-chip
+    :color="resolved.color"
+    :variant="variant"
+    :size="size"
+    :prepend-icon="resolved.icon"
+    label
+  >
+    {{ resolved.label }}
+  </v-chip>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue"
+
+export interface StatusDefinition {
+  color: string
+  icon?: string
+  label?: string
+}
+
+export type StatusMap = Record<string, StatusDefinition>
+
+/**
+ * Built-in mapping for the statuses that show up on 80% of admin apps.
+ * Override with the `map` prop for project-specific terminology.
+ */
+const DEFAULT_MAP: StatusMap = {
+  active:    { color: "success", icon: "check_circle" },
+  inactive:  { color: "grey",    icon: "remove_circle" },
+  draft:     { color: "warning", icon: "edit_note" },
+  pending:   { color: "info",    icon: "schedule" },
+  archived:  { color: "grey",    icon: "inventory_2" },
+  cancelled: { color: "error",   icon: "cancel" },
+  failed:    { color: "error",   icon: "error" },
+  completed: { color: "success", icon: "task_alt" },
+  paid:      { color: "success", icon: "payments" },
+  unpaid:    { color: "warning", icon: "request_quote" },
+  expired:   { color: "error",   icon: "history_toggle_off" },
+}
+
+const props = withDefaults(defineProps<{
+  value:   string
+  map?:    StatusMap
+  size?:   "x-small" | "small" | "default" | "large" | "x-large"
+  variant?: "elevated" | "flat" | "tonal" | "outlined" | "text" | "plain"
+}>(), {
+  map:     () => ({}),
+  size:    "small",
+  variant: "tonal",
+})
+
+const resolved = computed<Required<StatusDefinition>>(() => {
+  const fromCaller   = props.map[props.value]
+  const fromDefaults = DEFAULT_MAP[props.value]
+  const def          = fromCaller ?? fromDefaults ?? { color: "grey" }
+  return {
+    color: def.color,
+    icon:  def.icon  ?? "",
+    label: def.label ?? humanize(props.value),
+  }
+})
+
+function humanize(s: string): string {
+  return s.replace(/[-_]+/g, " ").replace(/\b\w/g, c => c.toUpperCase())
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/components/AppTimeAgo.vue
+++ b/resources/ts/components/AppTimeAgo.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-tooltip
+    location="top"
+    open-delay="200"
+  >
+    <template #activator="{ props: activatorProps }">
+      <span
+        v-bind="activatorProps"
+        class="app-time-ago"
+      >
+        {{ display }}
+      </span>
+    </template>
+    <span>{{ exact }}</span>
+  </v-tooltip>
+</template>
+
+<script lang="ts" setup>
+import { computed, onBeforeUnmount, onMounted, ref } from "vue"
+import { full_date_time, time_ago } from "@/utils/dayjs"
+
+const props = withDefaults(defineProps<{
+  /** ISO 8601 string, unix ms number, or null/undefined. */
+  value:        string | number | null | undefined
+  /** Fallback rendered when value is null/undefined/empty. */
+  emptyText?:   string
+  /** Refresh interval in ms — default 60s. Set to 0 to disable. */
+  refreshMs?:   number
+}>(), {
+  emptyText: "—",
+  refreshMs: 60_000,
+})
+
+// `tick` is a re-render trigger; bumping it on a timer recomputes the relative
+// display without re-fetching the timestamp.
+const tick = ref(0)
+
+const display = computed(() => {
+  void tick.value // dependency, intentionally unused
+  return props.value ? time_ago(props.value as string) || props.emptyText : props.emptyText
+})
+
+const exact = computed(() => props.value ? full_date_time(props.value as string) : "")
+
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  if (props.refreshMs > 0) {
+    intervalId = setInterval(() => { tick.value++ }, props.refreshMs)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (intervalId) clearInterval(intervalId)
+})
+</script>
+
+<style lang="scss" scoped>
+.app-time-ago {
+  cursor: help;
+  border-bottom: 1px dotted currentColor;
+  opacity: 0.85;
+}
+</style>

--- a/resources/ts/components/AppWizardSteps.vue
+++ b/resources/ts/components/AppWizardSteps.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="app-wizard">
+    <v-stepper
+      v-model="current"
+      :items="stepTitles"
+      :alt-labels="altLabels"
+      flat
+      class="bg-transparent"
+    />
+
+    <v-card
+      variant="outlined"
+      class="mt-4"
+    >
+      <v-card-text class="pa-4">
+        <slot :name="`step-${current}`" />
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-btn
+          variant="text"
+          :disabled="current === 1"
+          @click="previous"
+        >
+          Previous
+        </v-btn>
+        <v-spacer />
+        <span class="text-caption text-medium-emphasis me-2">
+          Step {{ current }} of {{ steps.length }}
+        </span>
+        <v-btn
+          v-if="!isLast"
+          color="primary"
+          :disabled="!canAdvance"
+          @click="next"
+        >
+          Next
+        </v-btn>
+        <v-btn
+          v-else
+          color="success"
+          :disabled="!canFinish"
+          :loading="finishing"
+          @click="onFinish"
+        >
+          {{ finishText }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue"
+
+export interface WizardStep {
+  title:  string
+  /** Set false to gate "Next" / "Finish" on this step. Undefined = always allowed. */
+  valid?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  steps:        WizardStep[]
+  /** 1-based step index. v-model. */
+  modelValue?:  number
+  finishText?:  string
+  finishing?:   boolean
+  altLabels?:   boolean
+}>(), {
+  modelValue: 1,
+  finishText: "Finish",
+  finishing:  false,
+  altLabels:  true,
+})
+
+const emit = defineEmits<{
+  "update:modelValue": [step: number]
+  finish:              []
+}>()
+
+const current = computed({
+  get: () => props.modelValue,
+  set: (v) => emit("update:modelValue", v),
+})
+
+// Prefix invalid steps with a warning glyph — without per-step v-slot
+// gymnastics, this stays both terse and Vuetify-version-agnostic.
+const stepTitles = computed(() =>
+  props.steps.map(s => s.valid === false ? `⚠ ${s.title}` : s.title),
+)
+
+const isLast     = computed(() => current.value === props.steps.length)
+const canAdvance = computed(() => props.steps[current.value - 1]?.valid !== false)
+const canFinish  = computed(() => props.steps.every(s => s.valid !== false))
+
+function previous() { if (current.value > 1) current.value-- }
+function next()     { if (current.value < props.steps.length && canAdvance.value) current.value++ }
+
+function onFinish() {
+  if (canFinish.value) emit("finish")
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/resources/ts/composables/useApi.ts
+++ b/resources/ts/composables/useApi.ts
@@ -49,12 +49,6 @@ export function useApi<T = unknown>(
     loading.value = true
     error.value   = null
     try {
-      const args: [string, AxiosRequestConfig?] =
-        method === "get" || method === "delete"
-          ? [endpoint, options.config]
-          // post/put/patch — config.data passed as body
-          : [endpoint, options.config]
-
       // axios signature differs for body vs no-body verbs; use the per-method
       // call so type narrowing works.
       let response
@@ -66,7 +60,6 @@ export function useApi<T = unknown>(
         case "patch":  response = await $http.patch (endpoint, options.config?.data, options.config); break
       }
 
-      void args
       data.value = response.data as T
       options.onSuccess?.(response.data as T)
       return response.data as T

--- a/resources/ts/composables/useApi.ts
+++ b/resources/ts/composables/useApi.ts
@@ -1,0 +1,87 @@
+import { onMounted, ref, type Ref } from "vue"
+import { $http } from "@/plugins/axios"
+import type { AxiosRequestConfig } from "axios"
+
+export interface UseApiOptions<T> {
+  /** HTTP method. Default "get". */
+  method?:    "get" | "post" | "put" | "patch" | "delete"
+  /** Body / params for the request. */
+  config?:    AxiosRequestConfig
+  /** Skip the initial fetch on mount. */
+  immediate?: boolean
+  /** Default value returned while loading or after an error. */
+  initial?:   T | null
+  /** Called on success. Useful for side-effects after the data lands. */
+  onSuccess?: (data: T) => void
+  /** Called when the request errors out. Receives the response (or undefined for network errors). */
+  onError?:   (err: unknown) => void
+}
+
+export interface UseApiReturn<T> {
+  data:    Ref<T | null>
+  error:   Ref<unknown | null>
+  loading: Ref<boolean>
+  /** Re-run the request. Resolves with the new data (or null on error). */
+  refresh: () => Promise<T | null>
+}
+
+/**
+ * Typed wrapper around $http with reactive data / error / loading state.
+ *
+ *   const { data: user, loading, error, refresh } = useApi<User>("/auth")
+ *
+ * Cuts the boilerplate around every "fetch on mount, show loader, surface
+ * error, expose refresh" page. Pages just bind `loading` to spinners and
+ * iterate `data` once it's there.
+ */
+export function useApi<T = unknown>(
+  endpoint: string,
+  options: UseApiOptions<T> = {},
+): UseApiReturn<T> {
+  const data    = ref<T | null>(options.initial ?? null) as Ref<T | null>
+  const error   = ref<unknown | null>(null)
+  const loading = ref(false)
+
+  const method    = options.method ?? "get"
+  const immediate = options.immediate ?? true
+
+  async function refresh(): Promise<T | null> {
+    loading.value = true
+    error.value   = null
+    try {
+      const args: [string, AxiosRequestConfig?] =
+        method === "get" || method === "delete"
+          ? [endpoint, options.config]
+          // post/put/patch — config.data passed as body
+          : [endpoint, options.config]
+
+      // axios signature differs for body vs no-body verbs; use the per-method
+      // call so type narrowing works.
+      let response
+      switch (method) {
+        case "get":    response = await $http.get   (endpoint, options.config); break
+        case "delete": response = await $http.delete(endpoint, options.config); break
+        case "post":   response = await $http.post  (endpoint, options.config?.data, options.config); break
+        case "put":    response = await $http.put   (endpoint, options.config?.data, options.config); break
+        case "patch":  response = await $http.patch (endpoint, options.config?.data, options.config); break
+      }
+
+      void args
+      data.value = response.data as T
+      options.onSuccess?.(response.data as T)
+      return response.data as T
+    } catch (e) {
+      error.value = e
+      options.onError?.(e)
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  if (immediate) {
+    onMounted(() => { void refresh() })
+  }
+
+  return { data, error, loading, refresh }
+}

--- a/resources/ts/composables/useDocumentTitle.ts
+++ b/resources/ts/composables/useDocumentTitle.ts
@@ -1,0 +1,44 @@
+import { onBeforeUnmount, watch, type Ref } from "vue"
+
+export interface UseDocumentTitleOptions {
+  /** Suffix appended after the page title, separated by " | ". Defaults to VITE_APP_NAME. */
+  suffix?:  string
+  /** Separator between the title and suffix. */
+  separator?: string
+  /** Set to false to skip restoring the previous title on unmount. */
+  restore?: boolean
+}
+
+/**
+ * Set document.title for the lifetime of the calling component.
+ *
+ *   useDocumentTitle("Edit Item")            // → "Edit Item | App Name"
+ *   useDocumentTitle(computed(() => name.value), { suffix: undefined })
+ *
+ * Accepts either a string (one-shot set) or a Ref/ComputedRef for reactivity.
+ * Restores the previous title on unmount unless `restore: false`.
+ */
+export function useDocumentTitle(
+  title: string | Ref<string>,
+  options: UseDocumentTitleOptions = {},
+): void {
+  const suffix    = options.suffix    ?? (import.meta.env.VITE_APP_NAME as string | undefined) ?? ""
+  const separator = options.separator ?? " | "
+  const restore   = options.restore   ?? true
+
+  const previous = document.title
+
+  function apply(raw: string) {
+    document.title = suffix && raw ? `${raw}${separator}${suffix}` : (raw || suffix || previous)
+  }
+
+  if (typeof title === "string") {
+    apply(title)
+  } else {
+    watch(title, (v) => apply(v ?? ""), { immediate: true })
+  }
+
+  if (restore) {
+    onBeforeUnmount(() => { document.title = previous })
+  }
+}

--- a/resources/ts/composables/useFilters.ts
+++ b/resources/ts/composables/useFilters.ts
@@ -1,0 +1,108 @@
+import { computed, reactive, watch, type ComputedRef } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import cloneDeep from "lodash.clonedeep"
+
+export interface UseFiltersOptions<T> {
+  /** Keys in `filters` that should NOT be synced to the URL (e.g. transient UI). */
+  exclude?: (keyof T)[]
+  /** Encoder for non-string values written to the URL. Defaults to String(). */
+  serialize?: (value: unknown) => string
+  /** Decoder for values read from the URL. Defaults to the initial-value type. */
+  deserialize?: (value: string, key: keyof T, initial: T) => unknown
+}
+
+export interface UseFiltersReturn<T extends object> {
+  /** Reactive filters object — bind to v-model. */
+  filters: T
+  /** Reset to the initial state (clears the URL too). */
+  reset:   () => void
+  /** True when ANY filter differs from its initial value. Useful to show a "clear" button. */
+  isActive: ComputedRef<boolean>
+}
+
+/**
+ * Reactive filter state that syncs to the URL query string. Refreshing the
+ * page preserves filters; back/forward navigates between filter states; copy/
+ * pasting a URL shares the exact view.
+ *
+ *   const { filters, reset, isActive } = useFilters({
+ *     search: "",
+ *     status: null as string | null,
+ *     owner_id: null as number | null,
+ *   })
+ *
+ *   <ItemFilterBar v-model="filters" />
+ *   <AppPaginationTable endpoint="items" :filters="filters" />
+ *   <v-btn v-if="isActive" @click="reset">Clear filters</v-btn>
+ */
+export function useFilters<T extends object>(
+  initial: T,
+  options: UseFiltersOptions<T> = {},
+): UseFiltersReturn<T> {
+  const route   = useRoute()
+  const router  = useRouter()
+  const exclude = new Set(options.exclude ?? [])
+
+  // Snapshot initial for reset + comparison.
+  const initialSnapshot = cloneDeep(initial)
+
+  // Seed from URL where present.
+  const seeded = { ...cloneDeep(initial) } as T
+  for (const key of Object.keys(initial) as (keyof T)[]) {
+    if (exclude.has(key)) continue
+    const fromUrl = route.query[key as string]
+    if (fromUrl === undefined) continue
+    const raw = Array.isArray(fromUrl) ? fromUrl[0] : fromUrl
+    if (raw === null) continue
+
+    if (options.deserialize) {
+      seeded[key] = options.deserialize(raw, key, initial) as T[keyof T]
+    } else {
+      // Best-effort default deserialization based on the initial value type
+      const init = initial[key]
+      if (typeof init === "number") seeded[key] = Number(raw) as T[keyof T]
+      else if (typeof init === "boolean") seeded[key] = (raw === "true") as T[keyof T]
+      else seeded[key] = raw as unknown as T[keyof T]
+    }
+  }
+
+  const filters = reactive(seeded) as T
+
+  watch(
+    () => cloneDeep(filters),
+    (newVal) => {
+      const query: Record<string, string> = {}
+      // Preserve any non-filter query keys (page=, etc. from other code paths)
+      for (const [k, v] of Object.entries(route.query)) {
+        if (k in initialSnapshot) continue
+        if (v !== null && v !== undefined) query[k] = Array.isArray(v) ? (v[0] ?? "") : v
+      }
+      for (const key of Object.keys(newVal) as (keyof T)[]) {
+        if (exclude.has(key)) continue
+        const v = newVal[key]
+        if (v === "" || v === null || v === undefined) continue
+        if (Array.isArray(v) && v.length === 0) continue
+        const same = JSON.stringify(v) === JSON.stringify((initialSnapshot as T)[key])
+        if (same) continue
+        query[key as string] = options.serialize ? options.serialize(v) : String(v)
+      }
+      void router.replace({ query })
+    },
+    { deep: true },
+  )
+
+  function reset() {
+    for (const key of Object.keys(initialSnapshot) as (keyof T)[]) {
+      ;(filters as T)[key] = cloneDeep((initialSnapshot as T)[key])
+    }
+  }
+
+  const isActive = computed(() => {
+    for (const key of Object.keys(initialSnapshot) as (keyof T)[]) {
+      if (JSON.stringify((filters as T)[key]) !== JSON.stringify((initialSnapshot as T)[key])) return true
+    }
+    return false
+  })
+
+  return { filters, reset, isActive }
+}

--- a/resources/ts/composables/useFilters.ts
+++ b/resources/ts/composables/useFilters.ts
@@ -46,31 +46,49 @@ export function useFilters<T extends object>(
   // Snapshot initial for reset + comparison.
   const initialSnapshot = cloneDeep(initial)
 
-  // Seed from URL where present.
-  const seeded = { ...cloneDeep(initial) } as T
-  for (const key of Object.keys(initial) as (keyof T)[]) {
-    if (exclude.has(key)) continue
-    const fromUrl = route.query[key as string]
-    if (fromUrl === undefined) continue
-    const raw = Array.isArray(fromUrl) ? fromUrl[0] : fromUrl
-    if (raw === null) continue
+  // Re-applied when seeding initially AND when the URL changes externally
+  // (back/forward, another component pushing a new query).
+  function applySeedFromUrl(target: T): void {
+    for (const key of Object.keys(initial) as (keyof T)[]) {
+      if (exclude.has(key)) continue
+      const fromUrl = route.query[key as string]
 
-    if (options.deserialize) {
-      seeded[key] = options.deserialize(raw, key, initial) as T[keyof T]
-    } else {
-      // Best-effort default deserialization based on the initial value type
-      const init = initial[key]
-      if (typeof init === "number") seeded[key] = Number(raw) as T[keyof T]
-      else if (typeof init === "boolean") seeded[key] = (raw === "true") as T[keyof T]
-      else seeded[key] = raw as unknown as T[keyof T]
+      // Absent in URL → reset to initial value (so back-navigating away from
+      // a filtered URL clears the filter, matching browser semantics).
+      if (fromUrl === undefined) {
+        target[key] = cloneDeep((initialSnapshot as T)[key])
+        continue
+      }
+      const raw = Array.isArray(fromUrl) ? fromUrl[0] : fromUrl
+      if (raw === null || raw === undefined) {
+        target[key] = cloneDeep((initialSnapshot as T)[key])
+        continue
+      }
+
+      if (options.deserialize) {
+        target[key] = options.deserialize(raw, key, initial) as T[keyof T]
+      } else {
+        // Best-effort default deserialization based on the initial value type
+        const init = initial[key]
+        if (typeof init === "number") target[key] = Number(raw) as T[keyof T]
+        else if (typeof init === "boolean") target[key] = (raw === "true") as T[keyof T]
+        else target[key] = raw as unknown as T[keyof T]
+      }
     }
   }
 
+  const seeded = { ...cloneDeep(initial) } as T
+  applySeedFromUrl(seeded)
   const filters = reactive(seeded) as T
+
+  // Guard against the filters↔URL loop: when we re-seed from a URL change,
+  // skip the next URL write that the filters watcher would emit.
+  let applyingFromUrl = false
 
   watch(
     () => cloneDeep(filters),
     (newVal) => {
+      if (applyingFromUrl) return
       const query: Record<string, string> = {}
       // Preserve any non-filter query keys (page=, etc. from other code paths)
       for (const [k, v] of Object.entries(route.query)) {
@@ -89,6 +107,17 @@ export function useFilters<T extends object>(
       void router.replace({ query })
     },
     { deep: true },
+  )
+
+  // External URL changes (browser back/forward, programmatic navigation) → filters.
+  // The flag prevents the filters watcher from echoing back to the URL.
+  watch(
+    () => route.query,
+    () => {
+      applyingFromUrl = true
+      applySeedFromUrl(filters)
+      void Promise.resolve().then(() => { applyingFromUrl = false })
+    },
   )
 
   function reset() {

--- a/resources/ts/composables/useSelection.ts
+++ b/resources/ts/composables/useSelection.ts
@@ -1,0 +1,102 @@
+import { computed, ref, type ComputedRef, type Ref } from "vue"
+
+export interface UseSelectionReturn<K> {
+  /** Reactive Set of selected keys. */
+  selectedKeys: Ref<Set<K>>
+  /** Reactive count for UX ("3 selected"). */
+  count:        ComputedRef<number>
+  /** Whether ALL items in the current page are selected. */
+  allSelected:  (items: { key: K }[] | K[]) => boolean
+  /** Whether SOME items are selected (for the indeterminate checkbox state). */
+  someSelected: (items: { key: K }[] | K[]) => boolean
+  isSelected:   (key: K) => boolean
+  toggle:       (key: K) => void
+  /** Select every key from `items`. Does NOT clear existing selections. */
+  selectAll:    (items: K[]) => void
+  /** Deselect every key from `items`. */
+  deselectAll:  (items: K[]) => void
+  /** Toggle between all-selected and none for `items`. */
+  toggleAll:    (items: K[]) => void
+  clear:        () => void
+}
+
+/**
+ * Multi-select state for table rows. Generic over the row key type (number or string).
+ *
+ *   const { selectedKeys, count, isSelected, toggle, toggleAll, clear } =
+ *     useSelection<number>()
+ *
+ *   // template:
+ *   <v-checkbox :model-value="isSelected(item.id)" @click.stop="toggle(item.id)" />
+ *   <v-btn v-if="count > 0" color="error" @click="bulkDelete">Delete {{ count }}</v-btn>
+ *
+ * Pairs with AppPaginationTable: pass `selectedKeys.value` (or `Array.from(selectedKeys.value)`)
+ * to your bulk-action handlers. AppPaginationTable doesn't dictate selection model so the
+ * composable owns it cleanly.
+ */
+export function useSelection<K = number>(): UseSelectionReturn<K> {
+  const selectedKeys = ref<Set<K>>(new Set()) as Ref<Set<K>>
+
+  function keyFor(x: { key: K } | K): K {
+    return typeof x === "object" && x !== null && "key" in (x as object)
+      ? (x as { key: K }).key
+      : (x as K)
+  }
+
+  const count = computed(() => selectedKeys.value.size)
+
+  function isSelected(key: K): boolean {
+    return selectedKeys.value.has(key)
+  }
+
+  function toggle(key: K) {
+    const next = new Set(selectedKeys.value)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    selectedKeys.value = next
+  }
+
+  function selectAll(items: K[]) {
+    const next = new Set(selectedKeys.value)
+    for (const k of items) next.add(keyFor(k))
+    selectedKeys.value = next
+  }
+
+  function deselectAll(items: K[]) {
+    const next = new Set(selectedKeys.value)
+    for (const k of items) next.delete(keyFor(k))
+    selectedKeys.value = next
+  }
+
+  function toggleAll(items: K[]) {
+    if (allSelected(items)) deselectAll(items)
+    else selectAll(items)
+  }
+
+  function allSelected(items: { key: K }[] | K[]): boolean {
+    if (!items.length) return false
+    return (items as K[]).every(k => selectedKeys.value.has(keyFor(k)))
+  }
+
+  function someSelected(items: { key: K }[] | K[]): boolean {
+    if (!items.length) return false
+    return (items as K[]).some(k => selectedKeys.value.has(keyFor(k)))
+  }
+
+  function clear() {
+    selectedKeys.value = new Set()
+  }
+
+  return {
+    selectedKeys,
+    count,
+    allSelected,
+    someSelected,
+    isSelected,
+    toggle,
+    selectAll,
+    deselectAll,
+    toggleAll,
+    clear,
+  }
+}

--- a/resources/ts/composables/useSelection.ts
+++ b/resources/ts/composables/useSelection.ts
@@ -6,9 +6,9 @@ export interface UseSelectionReturn<K> {
   /** Reactive count for UX ("3 selected"). */
   count:        ComputedRef<number>
   /** Whether ALL items in the current page are selected. */
-  allSelected:  (items: { key: K }[] | K[]) => boolean
+  allSelected:  (items: K[]) => boolean
   /** Whether SOME items are selected (for the indeterminate checkbox state). */
-  someSelected: (items: { key: K }[] | K[]) => boolean
+  someSelected: (items: K[]) => boolean
   isSelected:   (key: K) => boolean
   toggle:       (key: K) => void
   /** Select every key from `items`. Does NOT clear existing selections. */
@@ -37,12 +37,6 @@ export interface UseSelectionReturn<K> {
 export function useSelection<K = number>(): UseSelectionReturn<K> {
   const selectedKeys = ref<Set<K>>(new Set()) as Ref<Set<K>>
 
-  function keyFor(x: { key: K } | K): K {
-    return typeof x === "object" && x !== null && "key" in (x as object)
-      ? (x as { key: K }).key
-      : (x as K)
-  }
-
   const count = computed(() => selectedKeys.value.size)
 
   function isSelected(key: K): boolean {
@@ -58,13 +52,13 @@ export function useSelection<K = number>(): UseSelectionReturn<K> {
 
   function selectAll(items: K[]) {
     const next = new Set(selectedKeys.value)
-    for (const k of items) next.add(keyFor(k))
+    for (const k of items) next.add(k)
     selectedKeys.value = next
   }
 
   function deselectAll(items: K[]) {
     const next = new Set(selectedKeys.value)
-    for (const k of items) next.delete(keyFor(k))
+    for (const k of items) next.delete(k)
     selectedKeys.value = next
   }
 
@@ -73,14 +67,14 @@ export function useSelection<K = number>(): UseSelectionReturn<K> {
     else selectAll(items)
   }
 
-  function allSelected(items: { key: K }[] | K[]): boolean {
+  function allSelected(items: K[]): boolean {
     if (!items.length) return false
-    return (items as K[]).every(k => selectedKeys.value.has(keyFor(k)))
+    return items.every(k => selectedKeys.value.has(k))
   }
 
-  function someSelected(items: { key: K }[] | K[]): boolean {
+  function someSelected(items: K[]): boolean {
     if (!items.length) return false
-    return (items as K[]).some(k => selectedKeys.value.has(keyFor(k)))
+    return items.some(k => selectedKeys.value.has(k))
   }
 
   function clear() {

--- a/resources/ts/layouts/AdminLayout.vue
+++ b/resources/ts/layouts/AdminLayout.vue
@@ -55,7 +55,7 @@
       :rail="rail && !mdAndDown"
       :permanent="!mdAndDown"
       :temporary="mdAndDown"
-      @click="rail = false"
+      @click.self="rail = false"
     >
       <slot name="nav">
         <v-list

--- a/resources/ts/layouts/AdminLayout.vue
+++ b/resources/ts/layouts/AdminLayout.vue
@@ -1,0 +1,156 @@
+<template>
+  <v-app>
+    <app-messages />
+
+    <v-app-bar
+      :elevation="1"
+      color="surface"
+      density="comfortable"
+    >
+      <v-app-bar-nav-icon
+        v-if="mdAndDown"
+        @click="drawer = !drawer"
+      />
+
+      <slot name="brand">
+        <v-app-bar-title class="font-weight-bold">
+          {{ brand }}
+        </v-app-bar-title>
+      </slot>
+
+      <v-spacer />
+
+      <slot name="app-bar-actions" />
+
+      <slot name="user-menu">
+        <v-menu>
+          <template #activator="{ props: act }">
+            <v-btn
+              v-bind="act"
+              variant="text"
+              append-icon="expand_more"
+            >
+              {{ userName }}
+            </v-btn>
+          </template>
+          <v-list density="compact">
+            <v-list-item
+              prepend-icon="account_circle"
+              title="Profile"
+              @click="$emit('profile')"
+            />
+            <v-divider />
+            <v-list-item
+              prepend-icon="logout"
+              title="Log out"
+              @click="$emit('logout')"
+            />
+          </v-list>
+        </v-menu>
+      </slot>
+    </v-app-bar>
+
+    <v-navigation-drawer
+      v-model="drawer"
+      :rail="rail && !mdAndDown"
+      :permanent="!mdAndDown"
+      :temporary="mdAndDown"
+      @click="rail = false"
+    >
+      <slot name="nav">
+        <v-list
+          density="compact"
+          nav
+        >
+          <v-list-item
+            v-for="item in navItems"
+            :key="item.title"
+            :prepend-icon="item.icon"
+            :title="item.title"
+            :to="item.to"
+            :value="item.title"
+          />
+        </v-list>
+      </slot>
+
+      <template
+        v-if="!mdAndDown"
+        #append
+      >
+        <v-divider />
+        <v-list>
+          <v-list-item
+            :prepend-icon="rail ? 'chevron_right' : 'chevron_left'"
+            :title="rail ? '' : 'Collapse'"
+            @click.stop="rail = !rail"
+          />
+        </v-list>
+      </template>
+    </v-navigation-drawer>
+
+    <v-main>
+      <v-container :fluid="fluid">
+        <v-slide-x-reverse-transition mode="out-in">
+          <span class="transition-wrapper">
+            <slot />
+          </span>
+        </v-slide-x-reverse-transition>
+      </v-container>
+    </v-main>
+
+    <update-detector />
+  </v-app>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue"
+import { useDisplay } from "vuetify"
+import UpdateDetector from "@/components/UpdateDetector.vue"
+import AppMessages from "@/components/AppMessages.vue"
+import type { RouteLocationRaw } from "vue-router"
+
+export interface NavItem {
+  title: string
+  icon?: string
+  to:    RouteLocationRaw
+}
+
+export default defineComponent({
+  components: { AppMessages, UpdateDetector },
+  props: {
+    brand: {
+      type:    String,
+      default: "Admin",
+    },
+    userName: {
+      type:    String,
+      default: "Account",
+    },
+    navItems: {
+      type:    Array as PropType<NavItem[]>,
+      default: () => [],
+    },
+    fluid: {
+      type:    Boolean,
+      default: true,
+    },
+  },
+  emits: ["profile", "logout"],
+  setup() {
+    const { mdAndDown } = useDisplay()
+    return { mdAndDown }
+  },
+  data() {
+    return {
+      drawer: true,
+      rail:   false,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.transition-wrapper {
+  display: block;
+}
+</style>


### PR DESCRIPTION
## Summary

13 components, 4 composables, an AdminLayout, and a catalog doc — the small-but-everywhere pieces that show up in every project we ship. Composes with the existing `AppPaginationTable` / `AppServerValidationForm` / `\$auth` / `\$confirm` primitives without breaking any of them.

## What landed

**Display components:**
- `AppPageHeader` — title + subtitle + breadcrumbs + actions slot
- `AppStatusBadge` — v-chip with built-in color/icon map for 11 common statuses
- `AppTimeAgo` — self-updating "X minutes ago" with hover tooltip
- `AppMoneyDisplay` — Intl currency formatting + tabular numerals + negative styling
- `AppCopyableField` — inline value + copy-to-clipboard with check-mark feedback
- `AppInfoTooltip` — keyboard-accessible `?` help icon

**Action / interactive:**
- `AppFilterChips` — active filters as removable chips
- `AppConfirmActionButton` — button with `\$confirm` + loading state baked in
- `AppImpersonationBanner` — sticky "stop impersonating" banner (wires to existing /auth/stop-impersonating)
- `AppNotificationsBell` — bell + badge + dropdown shell (presentational; projects bring the data)
- `AppWizardSteps` — multi-step form with per-step validity gating
- `AppInlineEditField` — click-to-edit cell with async save support
- `AppDateRangePicker` — start/end + preset chips (Today / Last 30 / YTD / etc.)

**Layout:**
- `AdminLayout` — app bar + responsive nav drawer + user menu + every slot you need

**Composables:**
- `useApi<T>()` — `{ data, error, loading, refresh }` reactive fetch
- `useFilters()` — URL-synced filter state with reset + isActive
- `useSelection<K>()` — multi-select table state with allSelected/someSelected
- `useDocumentTitle()` — set + restore document.title per-page

**Docs:** `docs/Kit.md` — catalog + complete worked example (list page using 5 components + 2 composables together)

## Design principles

- **No new runtime deps.** Everything builds on what's already in `package.json`.
- **Composable, not opinionated.** Slots for everything custom; defaults sensible enough to drop in zero-config.
- **`<script setup lang="ts">` for components** (matches AppAutoComplete / AppServerValidationForm); Options API for pages (matches DashboardPage / LoginPage).
- **A11y by default.** Tab order, focus-visible, ARIA labels — no per-project work to make them keyboard-usable.
- **No hex literals in SCSS.** Theme tokens only (`rgb(var(--v-theme-X))`).

## Worked example

A typical list page using the kit removes ~150 lines of boilerplate per page — see `docs/Kit.md` for the full snippet.

## Test plan

- [ ] `npm run lint` clean
- [ ] `npm run build` clean
- [ ] Drop `AppStatusBadge`, `AppTimeAgo`, `AppMoneyDisplay`, `AppFilterChips`, `AppConfirmActionButton` into the canonical Item list page (from `feature/canonical-crud-example` when that merges)
- [ ] Wire `AdminLayout` into a project's router and verify drawer / user menu / responsive collapse
- [ ] Smoke test `useFilters` URL sync — change filter, refresh; back button returns to prior state
- [ ] Smoke test `AppInlineEditField` save path

## Conflicts

None expected vs the other four open template PRs — different files everywhere.

The kit composes BEST with the canonical Item example; once both merge, retrofit the Item pages to use `AppPageHeader` / `AppStatusBadge` / `AppFilterChips` / `useFilters` as a small follow-up.

19 commits, 18 new files + 1 doc.