### PR TITLE
feat(deps): upgrade Vuetify 3 → 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "laravel-vue-template",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -54,16 +54,16 @@
         "unplugin-fonts": "^1.0.0",
         "vite": "^7.3.2",
         "vite-plugin-eslint": "^1.0.0",
-        "vite-plugin-vuetify": "^2.0.0",
+        "vite-plugin-vuetify": "^2.1.3",
         "vitest": "^3.0.0",
-        "vue": "^3.0.0",
+        "vue": "^3.5.0",
         "vue-component-type-helpers": "^3.0.5",
         "vue-currency-input": "^3.1.0",
         "vue-imask": "^7.6.1",
         "vue-router": "^4.4.0",
         "vue-tsc": "^3.0.0",
         "vue-use-places-autocomplete": "^0.2.3",
-        "vuetify": "^3.0.0"
+        "vuetify": "^4.0.7"
       },
       "devDependencies": {
         "@types/lodash.foreach": "^4.5.9",
@@ -7914,9 +7914,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.6.tgz",
-      "integrity": "sha512-ARfflEJu+pKk+vya059qsUT/xUnYf0K6sIZdJwVh5w+kR6CJCXMQN1MONABb3Jm2kmhN/AXB4W5/MjYiKnVAFg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.0.7.tgz",
+      "integrity": "sha512-SV+YJkBmudY3s9qfZO2ZGUsrD0TDQU8pMBH1ERga9AEyjGvioZuXXh93V9wHxXJphvqRC2NW10Nt2lW9IZQcPw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -71,16 +71,16 @@
     "unplugin-fonts": "^1.0.0",
     "vite": "^7.3.2",
     "vite-plugin-eslint": "^1.0.0",
-    "vite-plugin-vuetify": "^2.0.0",
+    "vite-plugin-vuetify": "^2.1.3",
     "vitest": "^3.0.0",
-    "vue": "^3.0.0",
+    "vue": "^3.5.0",
     "vue-component-type-helpers": "^3.0.5",
     "vue-currency-input": "^3.1.0",
     "vue-imask": "^7.6.1",
     "vue-router": "^4.4.0",
     "vue-tsc": "^3.0.0",
     "vue-use-places-autocomplete": "^0.2.3",
-    "vuetify": "^3.0.0"
+    "vuetify": "^4.0.7"
   },
   "devDependencies": {
     "@types/lodash.foreach": "^4.5.9",

--- a/resources/scss/VBtn.scss
+++ b/resources/scss/VBtn.scss
@@ -1,6 +1,5 @@
 .v-btn {
   .v-btn__content {
-    text-transform: none;
     font-weight: 600;
   }
 }

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -4,33 +4,6 @@
 @use "VBtn";
 
 
-#applied {
-  h1 {
-    @extend .text-h1;
-  }
-
-  h2 {
-    @extend .text-h2;
-  }
-
-  h3 {
-    @extend .text-h3;
-  }
-
-  h4 {
-    @extend .text-h4;
-  }
-
-  h5 {
-    @extend .text-h5;
-  }
-
-  h6 {
-    @extend .text-h6;
-  }
-}
-
-
 
 
 

--- a/resources/ts/components/fields/AppAutoComplete/AppAutoComplete.vue
+++ b/resources/ts/components/fields/AppAutoComplete/AppAutoComplete.vue
@@ -73,7 +73,7 @@
         />
       </template>
 
-      <template #item="{ props: newProps, item }">
+      <template #item="{ props: newProps, internalItem: item }">
         <VListSubheader
           v-if="item?.raw?.type === 'subheader'"
           class="font-weight-bold"


### PR DESCRIPTION
## Summary
- Bumps Vuetify from ^3 to ^4.0.7 (plus vite-plugin-vuetify ^2.1.3 and Vue peer to ^3.5), with code migrated for the v4 breaking changes that actually affect this codebase.
- Only two component-level edits were required: `AppAutoComplete` adopts the new `internalItem` slot prop; `resources/scss/main.scss` no longer `@extend`s typography classes (impossible across v4's mandatory CSS layers).
- `resources/scss/VBtn.scss` drops the now-redundant `text-transform: none` override since v4 makes that the default.

## Migration notes
- **No other v4 breaking changes affect this repo:** no `v-snackbar multi-line`, no `v-date-picker` range usage (`AppDateRangePicker` uses two `AppDateInput`s, not v-date-picker), no `v-form` scoped slots, no `v-img` attribute-passthrough conflicts.
- **CSS layers** are now mandatory in v4. Order is already correct: `@vite(['resources/scss/main.scss', 'resources/ts/main.ts'])` loads styles before the app mounts.
- **Typography helper removed:** `#applied { h1 { @extend .text-h1; } ... }` is gone — projects that want typed headings should add `class="text-h*"` explicitly. v4 typography is responsive, so explicit classes are also the v4-idiomatic approach.
- **Visual:** v4's reduced default breakpoints, MD3 elevation, and grid overhaul are silent visual changes — please eyeball authenticated pages (AdminLayout, AppListTable, AppAutoComplete dropdown, AppDateInput menu) once merged.

## Test plan
- [x] `docker compose exec frontend npm install` — clean, 0 vulnerabilities
- [x] `npm run build` — clean (24 chunks, ~22s)
- [x] `npm run type-check` — zero net-new errors vs master (73 pre-existing errors unchanged)
- [x] `npm run lint` — clean
- [x] Browser smoke at 1280px + 375px: LoginPage renders correctly; v-card outlined, v-text-field prepend-inner icons, v-btn mixed-case text (v4 default `text-transform: none`), v-btn font-weight 600 still applies through layers, v-snackbar without multi-line, theme primary/error colors, material icons all working.
- [ ] **Human pass on authenticated pages** (login required, agent had no test creds): AdminLayout nav drawer + elevation, AppListTable, AppAutoComplete dropdown (new `internalItem` slot), AppDateInput menu picker, AppWizardSteps stepper.